### PR TITLE
fix adjoint quickstart

### DIFF
--- a/AdjointPlugin0Quickstart.ipynb
+++ b/AdjointPlugin0Quickstart.ipynb
@@ -141,7 +141,7 @@
     "    structures=[],\n",
     "    sources=[source],\n",
     "    output_monitors=[monitor],\n",
-    "    monitors=[fld_mnt],\n",
+    "    monitors=[],\n",
     "    run_time=120/freq0,\n",
     ")"
    ]
@@ -241,23 +241,10 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:44:33 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:44:33 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "with no box, intensity = 95.8381.\n",
+      "With no box, intensity = 95.8381.\n",
       "This value will be used for normalization of the objective function.\n"
      ]
     }
@@ -318,335 +305,47 @@
      "text": [
       "step = 1\n",
       "\tparam = -0.5000\n",
-      "\tsize = 2.5012 um\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:45:00 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:45:00 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:45:25 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:45:25 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tsize = 2.5012 um\n",
       "\tintensity = 5.9137e+00\n",
       "\tgrad_norm = 1.3624e+00\n",
       "step = 2\n",
       "\tparam = -0.4500\n",
-      "\tsize = 2.6882 um\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:45:49 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:45:49 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:46:13 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:46:13 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tsize = 2.6882 um\n",
       "\tintensity = 9.4693e+00\n",
       "\tgrad_norm = 2.1216e+00\n",
       "step = 3\n",
       "\tparam = -0.4006\n",
-      "\tsize = 2.8809 um\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:46:37 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:46:37 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:47:02 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:47:02 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tsize = 2.8809 um\n",
       "\tintensity = 1.1347e+01\n",
       "\tgrad_norm = 1.9069e+00\n",
       "step = 4\n",
       "\tparam = -0.3509\n",
-      "\tsize = 3.0823 um\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:47:27 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:47:27 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:47:51 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:47:51 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tsize = 3.0823 um\n",
       "\tintensity = 1.2976e+01\n",
       "\tgrad_norm = 2.3161e+00\n",
       "step = 5\n",
       "\tparam = -0.3008\n",
-      "\tsize = 3.2919 um\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:48:17 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:48:17 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:48:42 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:48:42 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tsize = 3.2919 um\n",
       "\tintensity = 1.6472e+01\n",
       "\tgrad_norm = 4.8547e+00\n",
       "step = 6\n",
       "\tparam = -0.2531\n",
-      "\tsize = 3.4978 um\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:49:06 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:49:06 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:49:32 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:49:32 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tsize = 3.4978 um\n",
       "\tintensity = 1.8129e+01\n",
       "\tgrad_norm = 2.0547e+00\n",
       "step = 7\n",
       "\tparam = -0.2058\n",
-      "\tsize = 3.7064 um\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:49:56 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:49:56 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:50:21 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:50:21 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tsize = 3.7064 um\n",
       "\tintensity = 1.7655e+01\n",
       "\tgrad_norm = 2.4113e+00\n",
       "step = 8\n",
       "\tparam = -0.1583\n",
-      "\tsize = 3.9201 um\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:50:47 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:50:47 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:51:12 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:51:12 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tsize = 3.9201 um\n",
       "\tintensity = 2.3258e+01\n",
       "\tgrad_norm = 2.0198e+00\n",
       "step = 9\n",
       "\tparam = -0.1112\n",
-      "\tsize = 4.1351 um\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:51:38 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:51:38 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:52:06 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:52:06 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tsize = 4.1351 um\n",
       "\tintensity = 2.2814e+01\n",
       "\tgrad_norm = 3.2321e+00\n"
      ]
@@ -729,21 +428,7 @@
    "execution_count": 15,
    "id": "9d9439d6-86bd-4e77-b5e5-e3e25f74c784",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">12:52:29 EST </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: updating Simulation from </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.5</span><span style=\"color: #800000; text-decoration-color: #800000\"> to </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.6</span><span style=\"color: #800000; text-decoration-color: #800000\">                       </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m12:52:29 EST\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: updating Simulation from \u001b[0m\u001b[1;36m2.5\u001b[0m\u001b[31m to \u001b[0m\u001b[1;36m2.6\u001b[0m\u001b[31m                       \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# construct simulation with final parameters\n",
     "sim_final = make_sim(param=param_history[-1])\n",


### PR DESCRIPTION
There was a monitor in the base `sim` that got moved below after I ran it.

This also gets rid of the warnings regarding converting 2.5 to 2.6