### PR TITLE
FEAT: Bring back smatrix updates, with added links updates

### DIFF
--- a/SMatrix.ipynb
+++ b/SMatrix.ipynb
@@ -196,29 +196,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[16:20:44] </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: Default value for the field monitor          </span> <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/monitor.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">monitor.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/monitor.py#261\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">261</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #008000; text-decoration-color: #008000\">'colocate'</span><span style=\"color: #800000; text-decoration-color: #800000\"> setting has changed to </span><span style=\"color: #008000; text-decoration-color: #008000\">'True'</span><span style=\"color: #800000; text-decoration-color: #800000\"> in Tidy3D    </span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">              </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2.4</span><span style=\"color: #800000; text-decoration-color: #800000\">.</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span><span style=\"color: #800000; text-decoration-color: #800000\">. All field components will be colocated to the  </span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">              </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #800000; text-decoration-color: #800000\">grid boundaries. Set to </span><span style=\"color: #008000; text-decoration-color: #008000\">'False'</span><span style=\"color: #800000; text-decoration-color: #800000\"> to get the raw fields </span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">              </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #800000; text-decoration-color: #800000\">on the Yee grid instead.                              </span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">              </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[16:20:44]\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: Default value for the field monitor          \u001b[0m \u001b]8;id=543129;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/monitor.py\u001b\\\u001b[2mmonitor.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=36399;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/monitor.py#261\u001b\\\u001b[2m261\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'colocate'\u001b[0m\u001b[31m setting has changed to \u001b[0m\u001b[32m'True'\u001b[0m\u001b[31m in Tidy3D    \u001b[0m \u001b[2m              \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b[1;36m2.4\u001b[0m\u001b[31m.\u001b[0m\u001b[1;36m0\u001b[0m\u001b[31m. All field components will be colocated to the  \u001b[0m \u001b[2m              \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b[31mgrid boundaries. Set to \u001b[0m\u001b[32m'False'\u001b[0m\u001b[31m to get the raw fields \u001b[0m \u001b[2m              \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b[31mon the Yee grid instead.                              \u001b[0m \u001b[2m              \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Geometry must be placed in GDS cells to import into Tidy3D\n",
     "coup_cell = gdstk.Cell(\"Coupler\")\n",
@@ -326,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-08-18T23:20:45.047501Z",
@@ -386,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-08-18T23:20:45.080639Z",
@@ -400,7 +378,7 @@
    "source": [
     "from tidy3d.plugins.smatrix.smatrix import ComponentModeler\n",
     "\n",
-    "modeler = ComponentModeler(simulation=sim, ports=ports, freqs=[freq0], verbose=True)\n"
+    "modeler = ComponentModeler(simulation=sim, ports=ports, freqs=[freq0], verbose=True, path_dir=\"data\")\n"
    ]
   },
   {
@@ -453,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-08-18T23:20:45.591645Z",
@@ -467,23 +445,13 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[16:20:45] </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: </span><span style=\"color: #008000; text-decoration-color: #008000\">'ComponentModeler'</span><span style=\"color: #800000; text-decoration-color: #800000\"> method was supplied a     </span> <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/plugins/smatrix/smatrix.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">smatrix.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/plugins/smatrix/smatrix.py#337\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">337</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #008000; text-decoration-color: #008000\">'path_dir'</span><span style=\"color: #800000; text-decoration-color: #800000\"> of </span><span style=\"color: #008000; text-decoration-color: #008000\">'data'</span><span style=\"color: #800000; text-decoration-color: #800000\"> when its internal </span><span style=\"color: #008000; text-decoration-color: #008000\">'path_dir'</span><span style=\"color: #800000; text-decoration-color: #800000\">     </span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">              </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #800000; text-decoration-color: #800000\">field was set to </span><span style=\"color: #008000; text-decoration-color: #008000\">'.'</span><span style=\"color: #800000; text-decoration-color: #800000\">. The passed value will be        </span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">              </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #800000; text-decoration-color: #800000\">deprecated in later versions. Please set the internal </span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">              </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #008000; text-decoration-color: #008000\">'path_dir'</span><span style=\"color: #800000; text-decoration-color: #800000\"> field to the desired value and remove the  </span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">              </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #008000; text-decoration-color: #008000\">'path_dir'</span><span style=\"color: #800000; text-decoration-color: #800000\"> from the method argument. Using supplied   </span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">              </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #008000; text-decoration-color: #008000\">'data'</span><span style=\"color: #800000; text-decoration-color: #800000\">.                                               </span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">              </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">14:51:32 PST </span>Created task <span style=\"color: #008000; text-decoration-color: #008000\">'smatrix_right_top_0'</span> with task_id                    \n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><span style=\"color: #008000; text-decoration-color: #008000\">'fdve-d673cc21-f0ae-45b5-890d-53d561516b84'</span> and task_type <span style=\"color: #008000; text-decoration-color: #008000\">'FDTD'</span>.  \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:20:45]\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: \u001b[0m\u001b[32m'ComponentModeler'\u001b[0m\u001b[31m method was supplied a     \u001b[0m \u001b]8;id=571216;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/plugins/smatrix/smatrix.py\u001b\\\u001b[2msmatrix.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=201139;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/plugins/smatrix/smatrix.py#337\u001b\\\u001b[2m337\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'path_dir'\u001b[0m\u001b[31m of \u001b[0m\u001b[32m'data'\u001b[0m\u001b[31m when its internal \u001b[0m\u001b[32m'path_dir'\u001b[0m\u001b[31m     \u001b[0m \u001b[2m              \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b[31mfield was set to \u001b[0m\u001b[32m'.'\u001b[0m\u001b[31m. The passed value will be        \u001b[0m \u001b[2m              \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b[31mdeprecated in later versions. Please set the internal \u001b[0m \u001b[2m              \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'path_dir'\u001b[0m\u001b[31m field to the desired value and remove the  \u001b[0m \u001b[2m              \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'path_dir'\u001b[0m\u001b[31m from the method argument. Using supplied   \u001b[0m \u001b[2m              \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'data'\u001b[0m\u001b[31m.                                               \u001b[0m \u001b[2m              \u001b[0m\n"
+       "\u001B[2;36m14:51:32 PST\u001B[0m\u001B[2;36m \u001B[0mCreated task \u001B[32m'smatrix_right_top_0'\u001B[0m with task_id                    \n",
+       "\u001B[2;36m             \u001B[0m\u001B[32m'fdve-d673cc21-f0ae-45b5-890d-53d561516b84'\u001B[0m and task_type \u001B[32m'FDTD'\u001B[0m.  \n"
       ]
      },
      "metadata": {},
@@ -492,30 +460,13 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>Created task <span style=\"color: #008000; text-decoration-color: #008000\">'smatrix_right_top_0'</span> with task_id         <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">webapi.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">188</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #008000; text-decoration-color: #008000\">'fdve-250f04b0-bd01-404e-be56-82a724b34014v1'</span>.          <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span>View task using web UI at <a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-d673cc21-f0ae-45b5-890d-53d561516b84\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">'https://tidy3d.simulation.cloud/workbenc</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-d673cc21-f0ae-45b5-890d-53d561516b84\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">h?taskId=fdve-d673cc21-f0ae-45b5-890d-53d561516b84'</span></a>.               \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mCreated task \u001b[32m'smatrix_right_top_0'\u001b[0m with task_id         \u001b]8;id=465679;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=997504;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001b\\\u001b[2m188\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'fdve-250f04b0-bd01-404e-be56-82a724b34014v1'\u001b[0m.          \u001b[2m             \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>View task using web UI at                               <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">webapi.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">190</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-250f04b0-bd01-404e-be56-82a724b34014v1\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">'https://tidy3d.simulation.cloud/workbench?taskId=fdve-</span></a> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-250f04b0-bd01-404e-be56-82a724b34014v1\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">250f04b0-bd01-404e-be56-82a724b34014v1'</span></a>.                <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mView task using web UI at                               \u001b]8;id=273011;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=653592;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001b\\\u001b[2m190\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=883109;https://tidy3d.simulation.cloud/workbench?taskId=fdve-250f04b0-bd01-404e-be56-82a724b34014v1\u001b\\\u001b[32m'https://tidy3d.simulation.cloud/workbench?\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=476862;https://tidy3d.simulation.cloud/workbench?taskId=fdve-250f04b0-bd01-404e-be56-82a724b34014v1\u001b\\\u001b[32mtaskId\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=883109;https://tidy3d.simulation.cloud/workbench?taskId=fdve-250f04b0-bd01-404e-be56-82a724b34014v1\u001b\\\u001b[32m=\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=658094;https://tidy3d.simulation.cloud/workbench?taskId=fdve-250f04b0-bd01-404e-be56-82a724b34014v1\u001b\\\u001b[32mfdve\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=883109;https://tidy3d.simulation.cloud/workbench?taskId=fdve-250f04b0-bd01-404e-be56-82a724b34014v1\u001b\\\u001b[32m-\u001b[0m\u001b]8;;\u001b\\ \u001b[2m             \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=883109;https://tidy3d.simulation.cloud/workbench?taskId=fdve-250f04b0-bd01-404e-be56-82a724b34014v1\u001b\\\u001b[32m250f04b0-bd01-404e-be56-82a724b34014v1'\u001b[0m\u001b]8;;\u001b\\.                \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m            \u001B[0m\u001B[2;36m \u001B[0mView task using web UI at \u001B]8;id=548772;https://tidy3d.simulation.cloud/workbench?taskId=fdve-d673cc21-f0ae-45b5-890d-53d561516b84\u001B\\\u001B[32m'https://tidy3d.simulation.cloud/workbenc\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m             \u001B[0m\u001B]8;id=548772;https://tidy3d.simulation.cloud/workbench?taskId=fdve-d673cc21-f0ae-45b5-890d-53d561516b84\u001B\\\u001B[32mh?\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=825314;https://tidy3d.simulation.cloud/workbench?taskId=fdve-d673cc21-f0ae-45b5-890d-53d561516b84\u001B\\\u001B[32mtaskId\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=548772;https://tidy3d.simulation.cloud/workbench?taskId=fdve-d673cc21-f0ae-45b5-890d-53d561516b84\u001B\\\u001B[32m=\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=825314;https://tidy3d.simulation.cloud/workbench?taskId=fdve-d673cc21-f0ae-45b5-890d-53d561516b84\u001B\\\u001B[32mfdve\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=548772;https://tidy3d.simulation.cloud/workbench?taskId=fdve-d673cc21-f0ae-45b5-890d-53d561516b84\u001B\\\u001B[32m-d673cc21-f0ae-45b5-890d-53d561516b84'\u001B[0m\u001B]8;;\u001B\\.               \n"
       ]
      },
      "metadata": {},
@@ -524,7 +475,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dd5571e46ddd490c98e78d741b07ca91",
+       "model_id": "6416b5261735432da4893c9e7ac4977b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -561,13 +512,13 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[16:20:46] </span>Created task <span style=\"color: #008000; text-decoration-color: #008000\">'smatrix_right_bot_0'</span> with task_id         <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">webapi.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">188</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #008000; text-decoration-color: #008000\">'fdve-fb655fca-e9c2-4ae9-819d-6a15f80d1132v1'</span>.          <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">14:51:33 PST </span>Created task <span style=\"color: #008000; text-decoration-color: #008000\">'smatrix_right_bot_0'</span> with task_id                    \n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><span style=\"color: #008000; text-decoration-color: #008000\">'fdve-373f561c-3060-4cae-9008-6da23117e557'</span> and task_type <span style=\"color: #008000; text-decoration-color: #008000\">'FDTD'</span>.  \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:20:46]\u001b[0m\u001b[2;36m \u001b[0mCreated task \u001b[32m'smatrix_right_bot_0'\u001b[0m with task_id         \u001b]8;id=532299;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=972676;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001b\\\u001b[2m188\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'fdve-fb655fca-e9c2-4ae9-819d-6a15f80d1132v1'\u001b[0m.          \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m14:51:33 PST\u001B[0m\u001B[2;36m \u001B[0mCreated task \u001B[32m'smatrix_right_bot_0'\u001B[0m with task_id                    \n",
+       "\u001B[2;36m             \u001B[0m\u001B[32m'fdve-373f561c-3060-4cae-9008-6da23117e557'\u001B[0m and task_type \u001B[32m'FDTD'\u001B[0m.  \n"
       ]
      },
      "metadata": {},
@@ -576,15 +527,13 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>View task using web UI at                               <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">webapi.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">190</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-fb655fca-e9c2-4ae9-819d-6a15f80d1132v1\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">'https://tidy3d.simulation.cloud/workbench?taskId=fdve-</span></a> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-fb655fca-e9c2-4ae9-819d-6a15f80d1132v1\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">fb655fca-e9c2-4ae9-819d-6a15f80d1132v1'</span></a>.                <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span>View task using web UI at <a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-373f561c-3060-4cae-9008-6da23117e557\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">'https://tidy3d.simulation.cloud/workbenc</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-373f561c-3060-4cae-9008-6da23117e557\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">h?taskId=fdve-373f561c-3060-4cae-9008-6da23117e557'</span></a>.               \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mView task using web UI at                               \u001b]8;id=836592;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=779003;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001b\\\u001b[2m190\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=701978;https://tidy3d.simulation.cloud/workbench?taskId=fdve-fb655fca-e9c2-4ae9-819d-6a15f80d1132v1\u001b\\\u001b[32m'https://tidy3d.simulation.cloud/workbench?\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=981817;https://tidy3d.simulation.cloud/workbench?taskId=fdve-fb655fca-e9c2-4ae9-819d-6a15f80d1132v1\u001b\\\u001b[32mtaskId\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=701978;https://tidy3d.simulation.cloud/workbench?taskId=fdve-fb655fca-e9c2-4ae9-819d-6a15f80d1132v1\u001b\\\u001b[32m=\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=844430;https://tidy3d.simulation.cloud/workbench?taskId=fdve-fb655fca-e9c2-4ae9-819d-6a15f80d1132v1\u001b\\\u001b[32mfdve\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=701978;https://tidy3d.simulation.cloud/workbench?taskId=fdve-fb655fca-e9c2-4ae9-819d-6a15f80d1132v1\u001b\\\u001b[32m-\u001b[0m\u001b]8;;\u001b\\ \u001b[2m             \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=701978;https://tidy3d.simulation.cloud/workbench?taskId=fdve-fb655fca-e9c2-4ae9-819d-6a15f80d1132v1\u001b\\\u001b[32mfb655fca-e9c2-4ae9-819d-6a15f80d1132v1'\u001b[0m\u001b]8;;\u001b\\.                \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m            \u001B[0m\u001B[2;36m \u001B[0mView task using web UI at \u001B]8;id=288896;https://tidy3d.simulation.cloud/workbench?taskId=fdve-373f561c-3060-4cae-9008-6da23117e557\u001B\\\u001B[32m'https://tidy3d.simulation.cloud/workbenc\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m             \u001B[0m\u001B]8;id=288896;https://tidy3d.simulation.cloud/workbench?taskId=fdve-373f561c-3060-4cae-9008-6da23117e557\u001B\\\u001B[32mh?\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=995404;https://tidy3d.simulation.cloud/workbench?taskId=fdve-373f561c-3060-4cae-9008-6da23117e557\u001B\\\u001B[32mtaskId\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=288896;https://tidy3d.simulation.cloud/workbench?taskId=fdve-373f561c-3060-4cae-9008-6da23117e557\u001B\\\u001B[32m=\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=995404;https://tidy3d.simulation.cloud/workbench?taskId=fdve-373f561c-3060-4cae-9008-6da23117e557\u001B\\\u001B[32mfdve\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=288896;https://tidy3d.simulation.cloud/workbench?taskId=fdve-373f561c-3060-4cae-9008-6da23117e557\u001B\\\u001B[32m-373f561c-3060-4cae-9008-6da23117e557'\u001B[0m\u001B]8;;\u001B\\.               \n"
       ]
      },
      "metadata": {},
@@ -593,7 +542,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b46823717ca34e37a3c2b977543fdfc1",
+       "model_id": "7b130e88ea2a45d4865dd3f7a6974bc7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -630,13 +579,13 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[16:20:47] </span>Created task <span style=\"color: #008000; text-decoration-color: #008000\">'smatrix_left_top_0'</span> with task_id          <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">webapi.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">188</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #008000; text-decoration-color: #008000\">'fdve-35cd21ba-c710-4a4b-82be-42b161393984v1'</span>.          <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span>Created task <span style=\"color: #008000; text-decoration-color: #008000\">'smatrix_left_top_0'</span> with task_id                     \n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><span style=\"color: #008000; text-decoration-color: #008000\">'fdve-e4779888-4800-49e8-af12-51f712dbb184'</span> and task_type <span style=\"color: #008000; text-decoration-color: #008000\">'FDTD'</span>.  \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:20:47]\u001b[0m\u001b[2;36m \u001b[0mCreated task \u001b[32m'smatrix_left_top_0'\u001b[0m with task_id          \u001b]8;id=721289;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=965098;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001b\\\u001b[2m188\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'fdve-35cd21ba-c710-4a4b-82be-42b161393984v1'\u001b[0m.          \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m            \u001B[0m\u001B[2;36m \u001B[0mCreated task \u001B[32m'smatrix_left_top_0'\u001B[0m with task_id                     \n",
+       "\u001B[2;36m             \u001B[0m\u001B[32m'fdve-e4779888-4800-49e8-af12-51f712dbb184'\u001B[0m and task_type \u001B[32m'FDTD'\u001B[0m.  \n"
       ]
      },
      "metadata": {},
@@ -645,15 +594,13 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>View task using web UI at                               <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">webapi.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">190</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-35cd21ba-c710-4a4b-82be-42b161393984v1\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">'https://tidy3d.simulation.cloud/workbench?taskId=fdve-</span></a> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-35cd21ba-c710-4a4b-82be-42b161393984v1\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">35cd21ba-c710-4a4b-82be-42b161393984v1'</span></a>.                <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span>View task using web UI at <a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-e4779888-4800-49e8-af12-51f712dbb184\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">'https://tidy3d.simulation.cloud/workbenc</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-e4779888-4800-49e8-af12-51f712dbb184\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">h?taskId=fdve-e4779888-4800-49e8-af12-51f712dbb184'</span></a>.               \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mView task using web UI at                               \u001b]8;id=473099;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=930579;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001b\\\u001b[2m190\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=956498;https://tidy3d.simulation.cloud/workbench?taskId=fdve-35cd21ba-c710-4a4b-82be-42b161393984v1\u001b\\\u001b[32m'https://tidy3d.simulation.cloud/workbench?\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=42604;https://tidy3d.simulation.cloud/workbench?taskId=fdve-35cd21ba-c710-4a4b-82be-42b161393984v1\u001b\\\u001b[32mtaskId\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=956498;https://tidy3d.simulation.cloud/workbench?taskId=fdve-35cd21ba-c710-4a4b-82be-42b161393984v1\u001b\\\u001b[32m=\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=825848;https://tidy3d.simulation.cloud/workbench?taskId=fdve-35cd21ba-c710-4a4b-82be-42b161393984v1\u001b\\\u001b[32mfdve\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=956498;https://tidy3d.simulation.cloud/workbench?taskId=fdve-35cd21ba-c710-4a4b-82be-42b161393984v1\u001b\\\u001b[32m-\u001b[0m\u001b]8;;\u001b\\ \u001b[2m             \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=956498;https://tidy3d.simulation.cloud/workbench?taskId=fdve-35cd21ba-c710-4a4b-82be-42b161393984v1\u001b\\\u001b[32m35cd21ba-c710-4a4b-82be-42b161393984v1'\u001b[0m\u001b]8;;\u001b\\.                \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m            \u001B[0m\u001B[2;36m \u001B[0mView task using web UI at \u001B]8;id=674396;https://tidy3d.simulation.cloud/workbench?taskId=fdve-e4779888-4800-49e8-af12-51f712dbb184\u001B\\\u001B[32m'https://tidy3d.simulation.cloud/workbenc\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m             \u001B[0m\u001B]8;id=674396;https://tidy3d.simulation.cloud/workbench?taskId=fdve-e4779888-4800-49e8-af12-51f712dbb184\u001B\\\u001B[32mh?\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=948533;https://tidy3d.simulation.cloud/workbench?taskId=fdve-e4779888-4800-49e8-af12-51f712dbb184\u001B\\\u001B[32mtaskId\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=674396;https://tidy3d.simulation.cloud/workbench?taskId=fdve-e4779888-4800-49e8-af12-51f712dbb184\u001B\\\u001B[32m=\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=948533;https://tidy3d.simulation.cloud/workbench?taskId=fdve-e4779888-4800-49e8-af12-51f712dbb184\u001B\\\u001B[32mfdve\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=674396;https://tidy3d.simulation.cloud/workbench?taskId=fdve-e4779888-4800-49e8-af12-51f712dbb184\u001B\\\u001B[32m-e4779888-4800-49e8-af12-51f712dbb184'\u001B[0m\u001B]8;;\u001B\\.               \n"
       ]
      },
      "metadata": {},
@@ -662,7 +609,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0252ae82166f40518901cc108a40e6bf",
+       "model_id": "bbf13511337445898f72681859a0c658",
        "version_major": 2,
        "version_minor": 0
       },
@@ -699,13 +646,13 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>Created task <span style=\"color: #008000; text-decoration-color: #008000\">'smatrix_left_bot_0'</span> with task_id          <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">webapi.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">188</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #008000; text-decoration-color: #008000\">'fdve-debdd199-f593-4223-8250-e9f91b7a330av1'</span>.          <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">14:51:34 PST </span>Created task <span style=\"color: #008000; text-decoration-color: #008000\">'smatrix_left_bot_0'</span> with task_id                     \n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><span style=\"color: #008000; text-decoration-color: #008000\">'fdve-611b08f2-8b4c-4bab-ad1b-4f50f703d3f4'</span> and task_type <span style=\"color: #008000; text-decoration-color: #008000\">'FDTD'</span>.  \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mCreated task \u001b[32m'smatrix_left_bot_0'\u001b[0m with task_id          \u001b]8;id=325310;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=566711;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001b\\\u001b[2m188\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'fdve-debdd199-f593-4223-8250-e9f91b7a330av1'\u001b[0m.          \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m14:51:34 PST\u001B[0m\u001B[2;36m \u001B[0mCreated task \u001B[32m'smatrix_left_bot_0'\u001B[0m with task_id                     \n",
+       "\u001B[2;36m             \u001B[0m\u001B[32m'fdve-611b08f2-8b4c-4bab-ad1b-4f50f703d3f4'\u001B[0m and task_type \u001B[32m'FDTD'\u001B[0m.  \n"
       ]
      },
      "metadata": {},
@@ -714,15 +661,13 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>View task using web UI at                               <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">webapi.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">190</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-debdd199-f593-4223-8250-e9f91b7a330av1\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">'https://tidy3d.simulation.cloud/workbench?taskId=fdve-</span></a> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-debdd199-f593-4223-8250-e9f91b7a330av1\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">debdd199-f593-4223-8250-e9f91b7a330av1'</span></a>.                <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span>View task using web UI at <a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-611b08f2-8b4c-4bab-ad1b-4f50f703d3f4\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">'https://tidy3d.simulation.cloud/workbenc</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><a href=\"https://tidy3d.simulation.cloud/workbench?taskId=fdve-611b08f2-8b4c-4bab-ad1b-4f50f703d3f4\" target=\"_blank\"><span style=\"color: #008000; text-decoration-color: #008000\">h?taskId=fdve-611b08f2-8b4c-4bab-ad1b-4f50f703d3f4'</span></a>.               \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mView task using web UI at                               \u001b]8;id=408085;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=261955;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001b\\\u001b[2m190\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=601846;https://tidy3d.simulation.cloud/workbench?taskId=fdve-debdd199-f593-4223-8250-e9f91b7a330av1\u001b\\\u001b[32m'https://tidy3d.simulation.cloud/workbench?\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=69335;https://tidy3d.simulation.cloud/workbench?taskId=fdve-debdd199-f593-4223-8250-e9f91b7a330av1\u001b\\\u001b[32mtaskId\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=601846;https://tidy3d.simulation.cloud/workbench?taskId=fdve-debdd199-f593-4223-8250-e9f91b7a330av1\u001b\\\u001b[32m=\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=36860;https://tidy3d.simulation.cloud/workbench?taskId=fdve-debdd199-f593-4223-8250-e9f91b7a330av1\u001b\\\u001b[32mfdve\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=601846;https://tidy3d.simulation.cloud/workbench?taskId=fdve-debdd199-f593-4223-8250-e9f91b7a330av1\u001b\\\u001b[32m-\u001b[0m\u001b]8;;\u001b\\ \u001b[2m             \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=601846;https://tidy3d.simulation.cloud/workbench?taskId=fdve-debdd199-f593-4223-8250-e9f91b7a330av1\u001b\\\u001b[32mdebdd199-f593-4223-8250-e9f91b7a330av1'\u001b[0m\u001b]8;;\u001b\\.                \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m            \u001B[0m\u001B[2;36m \u001B[0mView task using web UI at \u001B]8;id=365601;https://tidy3d.simulation.cloud/workbench?taskId=fdve-611b08f2-8b4c-4bab-ad1b-4f50f703d3f4\u001B\\\u001B[32m'https://tidy3d.simulation.cloud/workbenc\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m             \u001B[0m\u001B]8;id=365601;https://tidy3d.simulation.cloud/workbench?taskId=fdve-611b08f2-8b4c-4bab-ad1b-4f50f703d3f4\u001B\\\u001B[32mh?\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=702828;https://tidy3d.simulation.cloud/workbench?taskId=fdve-611b08f2-8b4c-4bab-ad1b-4f50f703d3f4\u001B\\\u001B[32mtaskId\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=365601;https://tidy3d.simulation.cloud/workbench?taskId=fdve-611b08f2-8b4c-4bab-ad1b-4f50f703d3f4\u001B\\\u001B[32m=\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=702828;https://tidy3d.simulation.cloud/workbench?taskId=fdve-611b08f2-8b4c-4bab-ad1b-4f50f703d3f4\u001B\\\u001B[32mfdve\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=365601;https://tidy3d.simulation.cloud/workbench?taskId=fdve-611b08f2-8b4c-4bab-ad1b-4f50f703d3f4\u001B\\\u001B[32m-611b08f2-8b4c-4bab-ad1b-4f50f703d3f4'\u001B[0m\u001B]8;;\u001B\\.               \n"
       ]
      },
      "metadata": {},
@@ -731,7 +676,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "85b42f398d8b468f9c7203377c7e618c",
+       "model_id": "c32b5b9c4292460eaaef4b225e37a2f7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -768,11 +713,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[16:20:49] </span>Started working on Batch.                            <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">container.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#475\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">475</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">14:51:37 PST </span>Started working on Batch.                                          \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:20:49]\u001b[0m\u001b[2;36m \u001b[0mStarted working on Batch.                            \u001b]8;id=776866;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001b\\\u001b[2mcontainer.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=572080;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#475\u001b\\\u001b[2m475\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001B[2;36m14:51:37 PST\u001B[0m\u001B[2;36m \u001B[0mStarted working on Batch.                                          \n"
       ]
      },
      "metadata": {},
@@ -781,15 +726,26 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[16:21:16] </span>Maximum FlexCredit cost: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1.763</span> for the whole batch.  <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">container.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#479\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">479</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>Use <span style=\"color: #008000; text-decoration-color: #008000\">'Batch.real_cost()'</span> to get the billed FlexCredit <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>cost after the Batch has completed.                  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">14:51:45 PST </span>Maximum FlexCredit cost: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1.839</span> for the whole batch.                \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:21:16]\u001b[0m\u001b[2;36m \u001b[0mMaximum FlexCredit cost: \u001b[1;36m1.763\u001b[0m for the whole batch.  \u001b]8;id=807892;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001b\\\u001b[2mcontainer.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=823422;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#479\u001b\\\u001b[2m479\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0mUse \u001b[32m'Batch.real_cost\u001b[0m\u001b[32m(\u001b[0m\u001b[32m)\u001b[0m\u001b[32m'\u001b[0m to get the billed FlexCredit \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0mcost after the Batch has completed.                  \u001b[2m                \u001b[0m\n"
+       "\u001B[2;36m14:51:45 PST\u001B[0m\u001B[2;36m \u001B[0mMaximum FlexCredit cost: \u001B[1;36m1.839\u001B[0m for the whole batch.                \n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span>Use <span style=\"color: #008000; text-decoration-color: #008000\">'Batch.real_cost()'</span> to get the billed FlexCredit cost after the\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span>Batch has completed.                                               \n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001B[2;36m            \u001B[0m\u001B[2;36m \u001B[0mUse \u001B[32m'Batch.real_cost\u001B[0m\u001B[32m(\u001B[0m\u001B[32m)\u001B[0m\u001B[32m'\u001B[0m to get the billed FlexCredit cost after the\n",
+       "\u001B[2;36m             \u001B[0mBatch has completed.                                               \n"
       ]
      },
      "metadata": {},
@@ -798,7 +754,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5646e481100d4dfe8dddf9f06a789d11",
+       "model_id": "d90950be8d8048109eb3ec3cd0ff3d86",
        "version_major": 2,
        "version_minor": 0
       },
@@ -812,11 +768,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[16:24:11] </span>Batch complete.                                      <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">container.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#522\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">522</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">14:51:46 PST </span>Batch complete.                                                    \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:24:11]\u001b[0m\u001b[2;36m \u001b[0mBatch complete.                                      \u001b]8;id=772435;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001b\\\u001b[2mcontainer.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=595516;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#522\u001b\\\u001b[2m522\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001B[2;36m14:51:46 PST\u001B[0m\u001B[2;36m \u001B[0mBatch complete.                                                    \n"
       ]
      },
      "metadata": {},
@@ -848,59 +804,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0b96d16273cb424fa829e224a23f7549",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[16:24:17] </span>loading SimulationData from                             <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">webapi.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">590</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>data/fdve-<span style=\"color: #ffff00; text-decoration-color: #ffff00\">250f04b0-bd01-404e-be56-82a724b34014</span>v1.hdf5   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[16:24:17]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=459471;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=892314;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0mdata/fdve-\u001b[93m250f04b0-bd01-404e-be56-82a724b34014\u001b[0mv1.hdf5   \u001b[2m             \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fb82653ad4a34e7b990c69495f54ee91",
+       "model_id": "8961e44853984d7299e7f4e920f18c07",
        "version_major": 2,
        "version_minor": 0
       },
@@ -937,13 +841,13 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[16:24:22] </span>loading SimulationData from                             <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">webapi.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">590</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>data/fdve-<span style=\"color: #ffff00; text-decoration-color: #ffff00\">fb655fca-e9c2-4ae9-819d-6a15f80d1132</span>v1.hdf5   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">14:51:48 PST </span>loading simulation from                                            \n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span>data/fdve-<span style=\"color: #ffff00; text-decoration-color: #ffff00\">d673cc21-f0ae-45b5-890d-53d561516b84</span>.hdf5                \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:24:22]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=50329;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=638828;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0mdata/fdve-\u001b[93mfb655fca-e9c2-4ae9-819d-6a15f80d1132\u001b[0mv1.hdf5   \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m14:51:48 PST\u001B[0m\u001B[2;36m \u001B[0mloading simulation from                                            \n",
+       "\u001B[2;36m             \u001B[0mdata/fdve-\u001B[93md673cc21-f0ae-45b5-890d-53d561516b84\u001B[0m.hdf5                \n"
       ]
      },
      "metadata": {},
@@ -952,7 +856,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7451e055cefd4f68ac1790a6a6d49614",
+       "model_id": "c0fdc27f022e4431b00326fbf08da73b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -989,13 +893,13 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[16:24:26] </span>loading SimulationData from                             <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">webapi.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">590</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>data/fdve-<span style=\"color: #ffff00; text-decoration-color: #ffff00\">35cd21ba-c710-4a4b-82be-42b161393984</span>v1.hdf5   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">14:51:49 PST </span>loading simulation from                                            \n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span>data/fdve-<span style=\"color: #ffff00; text-decoration-color: #ffff00\">373f561c-3060-4cae-9008-6da23117e557</span>.hdf5                \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:24:26]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=583293;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=687858;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0mdata/fdve-\u001b[93m35cd21ba-c710-4a4b-82be-42b161393984\u001b[0mv1.hdf5   \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m14:51:49 PST\u001B[0m\u001B[2;36m \u001B[0mloading simulation from                                            \n",
+       "\u001B[2;36m             \u001B[0mdata/fdve-\u001B[93m373f561c-3060-4cae-9008-6da23117e557\u001B[0m.hdf5                \n"
       ]
      },
      "metadata": {},
@@ -1004,7 +908,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "35b85d0a113448bbb5c9f5886962a444",
+       "model_id": "84757a9bfa61487782696095795b90c3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1041,13 +945,65 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[16:24:32] </span>loading SimulationData from                             <a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">webapi.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">590</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>data/fdve-<span style=\"color: #ffff00; text-decoration-color: #ffff00\">debdd199-f593-4223-8250-e9f91b7a330a</span>v1.hdf5   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">             </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">14:51:51 PST </span>loading simulation from                                            \n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span>data/fdve-<span style=\"color: #ffff00; text-decoration-color: #ffff00\">e4779888-4800-49e8-af12-51f712dbb184</span>.hdf5                \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:24:32]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=532441;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=138128;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0mdata/fdve-\u001b[93mdebdd199-f593-4223-8250-e9f91b7a330a\u001b[0mv1.hdf5   \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m14:51:51 PST\u001B[0m\u001B[2;36m \u001B[0mloading simulation from                                            \n",
+       "\u001B[2;36m             \u001B[0mdata/fdve-\u001B[93me4779888-4800-49e8-af12-51f712dbb184\u001B[0m.hdf5                \n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b117ca7e3f1b4890841dd971ddeb35b6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">14:51:52 PST </span>loading simulation from                                            \n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span>data/fdve-<span style=\"color: #ffff00; text-decoration-color: #ffff00\">611b08f2-8b4c-4bab-ad1b-4f50f703d3f4</span>.hdf5                \n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001B[2;36m14:51:52 PST\u001B[0m\u001B[2;36m \u001B[0mloading simulation from                                            \n",
+       "\u001B[2;36m             \u001B[0mdata/fdve-\u001B[93m611b08f2-8b4c-4bab-ad1b-4f50f703d3f4\u001B[0m.hdf5                \n"
       ]
      },
      "metadata": {},
@@ -1055,7 +1011,7 @@
     }
    ],
    "source": [
-    "smatrix = modeler.run(path_dir=\"data\")\n"
+    "smatrix = modeler.run()\n"
    ]
   },
   {
@@ -1072,7 +1028,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-08-18T23:24:35.280051Z",
@@ -1450,17 +1406,17 @@
        "  fill: currentColor;\n",
        "}\n",
        "</style><pre class='xr-text-repr-fallback'>&lt;xarray.SMatrixDataArray (f: 1)&gt;\n",
-       "array([0.33469665-0.61911863j])\n",
+       "array([0.33469842-0.61911778j])\n",
        "Coordinates:\n",
        "    port_out        &lt;U9 &#x27;right_bot&#x27;\n",
        "    port_in         &lt;U9 &#x27;left_top&#x27;\n",
        "    mode_index_out  int64 0\n",
        "    mode_index_in   int64 0\n",
-       "  * f               (f) float64 1.934e+14</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.SMatrixDataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>f</span>: 1</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-2164385e-95d8-4ebb-b27a-49688a7aea14' class='xr-array-in' type='checkbox' checked><label for='section-2164385e-95d8-4ebb-b27a-49688a7aea14' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>(0.33469664856537923-0.6191186341661973j)</span></div><div class='xr-array-data'><pre>array([0.33469665-0.61911863j])</pre></div></div></li><li class='xr-section-item'><input id='section-6e2237c2-29d8-434f-a674-faab4380cce6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-6e2237c2-29d8-434f-a674-faab4380cce6' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>port_out</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>&lt;U9</div><div class='xr-var-preview xr-preview'>&#x27;right_bot&#x27;</div><input id='attrs-cd0d41f6-514b-4a2a-9cd9-23a05c749f6f' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-cd0d41f6-514b-4a2a-9cd9-23a05c749f6f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0e4442d8-13db-4e58-a3fb-1850d41c579c' class='xr-var-data-in' type='checkbox'><label for='data-0e4442d8-13db-4e58-a3fb-1850d41c579c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(&#x27;right_bot&#x27;, dtype=&#x27;&lt;U9&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>port_in</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>&lt;U9</div><div class='xr-var-preview xr-preview'>&#x27;left_top&#x27;</div><input id='attrs-853cbd6b-49ab-4d58-8336-6214ee6ea9c7' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-853cbd6b-49ab-4d58-8336-6214ee6ea9c7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8129bcee-7456-4e70-b3c8-66b698227d21' class='xr-var-data-in' type='checkbox'><label for='data-8129bcee-7456-4e70-b3c8-66b698227d21' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(&#x27;left_top&#x27;, dtype=&#x27;&lt;U9&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>mode_index_out</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-2413bb74-13b5-41a3-938d-a23626ffc65e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-2413bb74-13b5-41a3-938d-a23626ffc65e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8eff3d43-15c2-47ba-871a-3584bdd312b7' class='xr-var-data-in' type='checkbox'><label for='data-8eff3d43-15c2-47ba-871a-3584bdd312b7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>mode_index_in</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-a7152bfb-c9a5-4a57-a824-75a0ee820bd3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a7152bfb-c9a5-4a57-a824-75a0ee820bd3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1937d427-8435-4627-a1db-c13e11ba7ad7' class='xr-var-data-in' type='checkbox'><label for='data-1937d427-8435-4627-a1db-c13e11ba7ad7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>f</span></div><div class='xr-var-dims'>(f)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.934e+14</div><input id='attrs-6c3522fa-e83f-412d-a8bb-b7bc13d52a70' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-6c3522fa-e83f-412d-a8bb-b7bc13d52a70' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8e98dc6b-7906-40c7-81a6-c46abd2dd4c6' class='xr-var-data-in' type='checkbox'><label for='data-8e98dc6b-7906-40c7-81a6-c46abd2dd4c6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([1.934145e+14])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-9dd080ec-558b-48a1-a8fd-7ef16db2e266' class='xr-section-summary-in' type='checkbox'  ><label for='section-9dd080ec-558b-48a1-a8fd-7ef16db2e266' class='xr-section-summary' >Indexes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>f</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-de773ff2-6409-4a27-8253-caf58e43dc33' class='xr-index-data-in' type='checkbox'/><label for='index-de773ff2-6409-4a27-8253-caf58e43dc33' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([193414489032258.06], dtype=&#x27;float64&#x27;, name=&#x27;f&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d3a34797-6082-4eb0-abb4-0f8932420af9' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-d3a34797-6082-4eb0-abb4-0f8932420af9' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "  * f               (f) float64 1.934e+14</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.SMatrixDataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>f</span>: 1</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-3b9ce888-9783-46b3-ba65-4a29476e70bd' class='xr-array-in' type='checkbox' checked><label for='section-3b9ce888-9783-46b3-ba65-4a29476e70bd' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>(0.3346984152858429-0.6191177755408744j)</span></div><div class='xr-array-data'><pre>array([0.33469842-0.61911778j])</pre></div></div></li><li class='xr-section-item'><input id='section-6faa051f-17ec-47b8-8dc6-8c66a94a31f9' class='xr-section-summary-in' type='checkbox'  checked><label for='section-6faa051f-17ec-47b8-8dc6-8c66a94a31f9' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>port_out</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>&lt;U9</div><div class='xr-var-preview xr-preview'>&#x27;right_bot&#x27;</div><input id='attrs-7cdcdd64-b919-4f52-9cc1-4d8417b58b60' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7cdcdd64-b919-4f52-9cc1-4d8417b58b60' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a55820ed-64fe-4d29-93bb-5d7a0f94142f' class='xr-var-data-in' type='checkbox'><label for='data-a55820ed-64fe-4d29-93bb-5d7a0f94142f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(&#x27;right_bot&#x27;, dtype=&#x27;&lt;U9&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>port_in</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>&lt;U9</div><div class='xr-var-preview xr-preview'>&#x27;left_top&#x27;</div><input id='attrs-160fc569-499a-4437-99ea-5f023a5cb909' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-160fc569-499a-4437-99ea-5f023a5cb909' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-53a39fd9-3fa1-4dad-9170-d8563d8efdea' class='xr-var-data-in' type='checkbox'><label for='data-53a39fd9-3fa1-4dad-9170-d8563d8efdea' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(&#x27;left_top&#x27;, dtype=&#x27;&lt;U9&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>mode_index_out</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-ddfdff2e-7e2f-4f8d-91ab-d69476f7287a' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-ddfdff2e-7e2f-4f8d-91ab-d69476f7287a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2100e702-6c2a-4765-83d2-4a6b23ec9365' class='xr-var-data-in' type='checkbox'><label for='data-2100e702-6c2a-4765-83d2-4a6b23ec9365' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>mode_index_in</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-4b1acc8c-d773-4973-82fe-e3363e823499' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4b1acc8c-d773-4973-82fe-e3363e823499' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5c730f9d-bc5e-43f7-ad8c-2e229d23d569' class='xr-var-data-in' type='checkbox'><label for='data-5c730f9d-bc5e-43f7-ad8c-2e229d23d569' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>f</span></div><div class='xr-var-dims'>(f)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.934e+14</div><input id='attrs-b7fedbb3-ac7c-4068-9446-b792765699cb' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b7fedbb3-ac7c-4068-9446-b792765699cb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-02796712-e32a-4e71-b49f-820eff0f5115' class='xr-var-data-in' type='checkbox'><label for='data-02796712-e32a-4e71-b49f-820eff0f5115' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([1.934145e+14])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-3d7983b7-710d-4549-93c0-cfb62326bb76' class='xr-section-summary-in' type='checkbox'  ><label for='section-3d7983b7-710d-4549-93c0-cfb62326bb76' class='xr-section-summary' >Indexes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>f</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-082ac813-53ad-4b7b-8617-7bfb82914be5' class='xr-index-data-in' type='checkbox'/><label for='index-082ac813-53ad-4b7b-8617-7bfb82914be5' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([193414489032258.06], dtype=&#x27;float64&#x27;, name=&#x27;f&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1e798ca5-cc51-43d4-9a69-63d319fb1cf8' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-1e798ca5-cc51-43d4-9a69-63d319fb1cf8' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.SMatrixDataArray (f: 1)>\n",
-       "array([0.33469665-0.61911863j])\n",
+       "array([0.33469842-0.61911778j])\n",
        "Coordinates:\n",
        "    port_out        <U9 'right_bot'\n",
        "    port_in         <U9 'left_top'\n",
@@ -1469,7 +1425,7 @@
        "  * f               (f) float64 1.934e+14"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1489,7 +1445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-08-18T23:24:35.307422Z",
@@ -1559,14 +1515,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we can check whether `S` is close to unitary as expected.\n",
+    "There is a little power loss since the coupler was not optimized, most likely scattering from the bends and coupling region.\n",
     "\n",
-    "S times it's Hermitian conjugate should be the identy matrix."
+    "Finally, we can check whether `S` is close to unitary as expected. S times it's Hermitian conjugate should be the identy matrix."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 10,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-08-18T23:24:35.363490Z",
@@ -1583,7 +1539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-08-18T23:24:35.404907Z",
@@ -1596,12 +1552,14 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAFTCAYAAAAk628HAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAABVR0lEQVR4nO3de3wU5dn/8e9uIAkICSCEEIgEREFEDgZJA6gokaDWp/izVBTLoRZqJZ5CFbAKCJWIII1aSsQKHhEetdDWA4rQQHmMgLHUQyWKilAgAUQIBElgd35/YLauyYbMZCe7O/t5+7pfurP3zNzD4XKu3CeXYRiGAAAAAABA0LlD3QAAAAAAAJyKpBsAAAAAAJuQdAMAAAAAYBOSbgAAAAAAbELSDQAAAACATUi6AQAAAACwCUk3AAAAAAA2IekGAAAAAMAmJN0AAAAAANiEpBsAAAAAAJuQdAMAAAAA6m3Dhg265pprlJKSIpfLpVWrVtl+z927d+umm27SmWeeqWbNmumCCy7Qe++9Z/t9g4GkGwAAAABQbxUVFerTp48WLlzYKPf75ptvNGjQIDVt2lRvvPGG/v3vf+uRRx5R69atG+X+DeUyDMMIdSMAAAAAAJHH5XJp5cqVGjFihO9YZWWlfvvb3+rFF1/UoUOH1KtXL82dO1dDhgyxdI+pU6fq//7v//SPf/wjOI1uZPR0AwAAAACCJicnR0VFRVq+fLk++OADjRw5UsOHD9dnn31m6Xp//etf1b9/f40cOVJJSUnq16+fnnzyySC32j70dAMAAAAALPlhT/fOnTvVtWtX7dy5UykpKb56WVlZGjBggObMmWP6HvHx8ZKk3NxcjRw5Ulu2bNEdd9yhgoICjR07NijPYacmoW4AAAAAAMAZPvzwQ3k8Hp177rl+xysrK3XmmWdKkrZt26bzzjuvzutMmTJFDz30kCTJ6/Wqf//+voS9X79++uijj0i6AQAAAADR5ejRo4qJiVFxcbFiYmL8vmvRooUkqWvXrvrkk0/qvE51gi5JHTp0UM+ePf2+P++88/TKK68EqdX2IulGvY0bN05DhgzRuHHjQt0UAAAAAGGoX79+8ng82rdvny6++OJa68TGxqpHjx71vuagQYNUUlLid+zTTz9V586dG9TWxkLSDQAAAACot6NHj2r79u2+z19++aW2bt2qNm3a6Nxzz9Xo0aM1ZswYPfLII+rXr5/279+vtWvXqnfv3rr66qtN3++uu+7SwIEDNWfOHP3sZz/T5s2btXjxYi1evDiYj2UbVi93uLS0NM2cObNB1xg5cqRatGihF154QbfccotatGihxx57LOTtAoBIN27cOD399NOhbgYARBRiZ+i999576tevn/r16yfp1AJn/fr10/Tp0yVJS5cu1ZgxYzR58mR1795dI0aM0JYtW3TWWWdZut9FF12klStX6sUXX1SvXr00e/Zs5efna/To0UF7JjvR0x2lPvjgA82dO1eFhYXav3+/2rRpo27duumKK67QjBkz/Oq+9NJLkuo/vNzMtQEAAABEliFDhqiuTbCaNm2qBx54QA888EDQ7vnjH/9YP/7xj4N2vcZET3cU+vOf/6yLLrpImzdv1q9+9Sv98Y9/1MSJE+X1evX888+H7bUBIFQef/xxde/eXXFxcUEZpWPHCKIuXbooISFBl156qT744IMGtxEAGorYCZzCPt0Ol5aWpnHjxvkC3TfffKMuXbqoV69eWrdunWJjY/3q79mzx28/ve87XU+3mWv/sF0IP8ePH1dVVZWlc2NjY337KQKh9tVXX2ns2LHasmWL+vTpo0WLFqlPnz765JNPVFBQoL/85S/65ptv9Pjjj2vMmDE1zv/888/VrVs39e7dW7fccosGDRqk3r1716hnZZRPfUYQ1fe6K1eu1L///W89/PDD6tOnjzZs2GD+FwsNRuyEE3311VdasGCBtm7dqri4OA0ePFhXXXWVzj//fB0/flylpaU1tn8idsIsJ8dPhpdHmbfffluHDx/WzTffXCMplhQw4Q71tdG4jh8/ri6dW6h0n8fS+cnJyfryyy/DOvghetx000268cYbNWXKFP3iF7/Q0KFDNXjwYH377beaOHGiLr30Uo0cOVJz5sypNen+5z//KUl68MEHAw5r+/Of/6wbbrhBZ511ln71q18pJSVFO3fu1Ntvv63nn3/e8tQaM9e99tprde211+qrr77S8uXLLd0PDXP8+HE1a9lGOvmtpfOJnQhH27Zt07x581RZWanKykr94x//0Jo1a3zx59JLL9X//u//1jiP2AkznB4/SbqjTEVFhSTZMnzGzmujcVVVVal0n0dfFndWQktzs1DKj3jVJf0rVVVVhW3gQ/QoLi5W165d9etf/1qSNHv2bE2YMEGDBg3S3Xff7avXrVs3nTx5stZrVMe29u3b1/r9N998o1/84he66KKLaozymTVrlvbs2WOp7Vavm5ycrCNHjli6JxqmqqpKOvmtmva6QYppau5kzwmVfvQisRNhp3v37nrqqad8n/fs2aMNGzaooqJC3bp106pVq2rtnSR2wgynx0+S7ihz2WWXqXnz5srPz9drr72ma6+9VsOHD9cll1xSY/P6cLo2QiOhpdt00g2Ek507d+pHP/qR7/NFF11Ua70jR47ouuuuq/W76llYLper1u/tGuVj9bpuN39nQy6mqVwxNX/P6sJcP4SrH8a+lJQUjRo1SpI0bdo0vf322/r9739f4zxiJyxxaPzkT1eU6dy5s4qKivSzn/1Me/bs0cMPP6zLL79cXbt21dtvv13nufHx8WraNPBPnhpybYQnj+G1VIBw0a1bN33xxRe+z2eccYak//bASNI//vEPVVRUaOrUqbVew+s99Wc60AuZXaN8rF63+gW3ut1ofC53jKUCRJqXXnpJHk/tU9GInbDCqfGTpDsK9e7dWytWrNDBgwf197//XePHj9euXbs0atQoHTt2LOB5BQUFp90Lz+q1EZ68MiwVIFxccMEF2rlzpz7++ONav//qq6/0i1/8QitWrFDHjh1rrVM9FLFVq1a1fv/9UT7nnnuupkyZor///e8BX0Try+p1ExMTJUl79+5t0P1hnVNfGoEfOnjwoLZt26ZPP/20xnfETljh1PhJ0h3FYmNjNWTIEC1ZskRXX321vv76a5WUlIT9tdF4vBb/AcLJwoUL9dBDD2njxo2+Y8eOHdPDDz+sCy64QNu3b9f9999fo3fjwIED+sc//qE//elP6tq1q7p06VLr9e0aQWT1uhdffLFcLpfuu+8+ffbZZ/zAMwRcLgsvja7wf2kEfuiSSy6RYRh6+umnfceInWgIp8ZPkm5IkuLi4iT996d8kXJt2MtjGJYKEE7atm2r5557ToMHD/Yde/HFF+V2u1VUVKQ+ffrovffe07vvvut3Xv/+/XXJJZeoqqpKK1euDDgvUbJvBJGV66anpys/P1/PPvuszj33XD388MMBrw97uGLccsXEmCy8kiHyVC9SWVRU5DtG7ERDODV+hn8LETQbN27Ut9/WXIb/gw8+0OrVq9WvXz917do17K6N0GF4OZzq5ptv1m9+8xudf/75Gj9+vCTpX//6l1+dZ599VgsXLlRVVZXGjh3rWxSoLnaN8jFz3Y8//lhTpkzRZZddppdffrnWbdBgL7c7xlIBIs0VV1yhxMREv3UyiJ1oCKfGT1YvjyJTp07Vp59+qpEjR6pPnz46efKktm7dqueee06JiYl67rnnwvLaAGBVZWWl9u7dq7S0NEnybQv2/WGJ5557rqRTQyK/75JLLtEll1yiffv26YEHHtAXX3yhs88+u973tmuUz+mu+9Zbb+n48eN66qmn1Llz56DeGwC+z+12q1WrVr7VzCViJ1AberqjyOTJk5WVlaW33npLubm5mjx5sjZu3KjbbrtNH374oc4///ywvDZCxytDHpOFnm6Ek5iYGN12222+z19++aUk+ZJwSTrzzDMlndpezOPx1OiVOeussyRJhw4dqnF9u0b5NOS65eXlkqTU1FTT90VwOHUhIESvTZs26ZlnnqkxIuidd95RSkqKbr/99hrnEDthhVPjJz3dUeTaa6/VtddeG3HXRuhYGS5O0o1w0qRJE6WkpGjz5s268MIL9cgjj6ht27a6+uqrfXW6desmt9utVatWafPmzVqxYoV69Ojh+756u5vahkjaNcqnIdetbid7zoaOpZfACHhpRHSaNWuWZsyY4ft8/fXXKy8vTwcPHtS0adP00ksvqUmTmikFsRNWODV+knQDCMjKwmgspIZw88gjjyg3N1cbN25UfHy8Xn31Vb8tbNq0aeN7Qbv11ltrDD2MiTn1P/Pjx4/XuPbkyZP10ksv6a233tIzzzwjj8ejLl266LbbbtPdd9+tdu3aWWpzQ6777bff+tqM0HC53XKZfXHnRR9hyOPxaNSoUZo2bZo2bdqkvLw8rVixQi+99JJ+/OMfa9myZQG3WyR2wgqnxk+SbgABeb8rZs8BwkmLFi20ePHiOussX7484HfVL5TPPfecUlNT1a5dOzVv3lySfaN8rFz34MGD2r17t1avXh3wJRiNw6k9NYg+MTExvnUvBg8erNdee0379u1TXFzcaedcEzthhVPjZ/j/WABAyJidz11dACe5+OKLNWjQIC1evFhpaWlhu43MhRdeqN69e+vjjz/W3XffHermRLVTPTVm5yTySobIkJSUVK9FzoidsMKp8ZOebofbsWNHqJtQq3BtF/x5jFPF7DmAkzRt2lQbN27U9u3btXv37rBdZGfZsmVyuVzq0aOHWrduHermRDWXy0JPjSv8e2oAM4idsMKp8ZOkGwCAeujWrZu6desW6mYENHDgwFA3AQBqIHYCJN0A6sCcbgCwICZGLpMLMhne8O+pAQDbOTR+knQDCMgrlzxymT4HAKKZlYWAImGfWQCwm1PjJ0k3gIC8xqli9hwAiGZOfWkEALs5NX6SdAMIyGOhp9tsfQBwGrc7Rm4HbnkDAHZzavwk6QYQEEk3AJhXveWN2XMAINo5NX6GfwsbYOHChUpLS1N8fLwyMjK0efPmUDepwTZs2KBrrrlGKSkpcrlcWrVqVaibFDR5eXm66KKL1LJlSyUlJWnEiBEqKSkJdbOCYtGiRerdu7cSEhKUkJCgzMxMvfHGG6FuFlArJ8ZOybnx08mxUyJ+IrIQPyOLk+MnsTO8ODbpXrFihXJzczVjxgy9//776tOnj7Kzs7Vv375QN61BKioq1KdPHy1cuDDUTQm69evXa9KkSXr33Xe1Zs0anThxQsOGDVNFRUWom9ZgnTp10kMPPaTi4mK99957uvzyy/WTn/xEH3/8caibViev4bJUELmcGjsl58ZPJ8dOKTLjZ/WcRLMFkY34GXmcHD8jMXZKzo2fLsMwHLnsUUZGhi666CL94Q9/kCR5vV6lpqbqtttu09SpU0PcuuBwuVxauXKlRowYEeqm2GL//v1KSkrS+vXrdckll4S6OUHXpk0bzZs3TzfffHOom1JDeXm5EhMTtf6jjmrR0tzP5o4e8erSXrt1+PBhJSQk2NRC2CUaYqfk7Pjp9NgphW/8rI6dydfly920malzvSe+VekrdxI7IxjxM/I5PX6Ga+yUnB8/HdnTXVVVpeLiYmVlZfmOud1uZWVlqaioKIQtgxmHDx+WdCpAOInH49Hy5ctVUVGhzMzMUDenTh65LRVEJmKnMzg1dkqREz+d2lODwIifzuDU+BkpsVNybvx05EJqBw4ckMfjUfv27f2Ot2/fXtu2bQtRq2CG1+vVnXfeqUGDBqlXr16hbk5QfPjhh8rMzNTx48fVokULrVy5Uj179gx1s+pkWBgubjC8PGIROyOfE2OnFHnx0+WysOWNK/xfGhEY8TPyOTF+RlrslJwbPx2ZdCPyTZo0SR999JE2btwY6qYETffu3bV161YdPnxYL7/8ssaOHav169eHdfBj9XIgsjgxdkqRFz9dMTFyxZh8aTRZH0BwOTF+RlrslJwbPx2ZdLdt21YxMTEqKyvzO15WVqbk5OQQtQr1lZOTo1dffVUbNmxQp06dQt2coImNjVW3bt0kSenp6dqyZYseffRRPfHEEyFuGXAKsTOyOTV2SsRPhD/iZ2RzavwkdoYPR06+jI2NVXp6utauXes75vV6tXbt2rCfxxDNDMNQTk6OVq5cqXXr1qlLly6hbpKtvF6vKisrQ92MOnkMt6WCyETsjEzRFjul8I+f1fvMmivEzkhG/IxM0RY/wz12So0XP3fv3q2bbrpJZ555ppo1a6YLLrhA7733ng1PdIoje7olKTc3V2PHjlX//v01YMAA5efnq6KiQuPHjw910xrk6NGj2r59u+/zl19+qa1bt6pNmzY666yzQtiyhps0aZKWLVumv/zlL2rZsqVKS0slSYmJiWrWzNwqhuFm2rRpuvLKK3XWWWfpyJEjWrZsmQoLC/Xmm2+Guml18solr8mfzXnlyA0RooZTY6fk3Pjp5NgpRWb8tLKwTyQsBIS6ET8jj5PjZyTGTqlx4uc333yjQYMG6bLLLtMbb7yhdu3a6bPPPlPr1q1NXccMxybd119/vfbv36/p06ertLRUffv21erVq2sscBFp3nvvPV122WW+z7m5uZKksWPH6umnnw5Rq4Jj0aJFkqQhQ4b4HV+6dKnGjRvX+A0Kon379mnMmDHau3evEhMT1bt3b7355pu64oorQt20OjGnO/o4NXZKzo2fTo6dUmTGT5Lu6ET8jDxOjp+RGDulhsXP8vJyv+NxcXGKi4urUX/u3LlKTU3V0qVLfcfsHuXg2H26AVhXvVfiyn+dozNamgt8FUc8urbPZ2G9VyIA2KE6dqaNf1bu2OamzvVWHdOOpWOInQCiUjDi5w/NmDFDM2fOrHG8Z8+eys7O1n/+8x+tX79eHTt21K233qoJEyZYbf5pObanG0DDnRpebq7n2mx9AHAal9sll9tcLDRbHwCcqCHxc9euXX4/tKytl1uSvvjiCy1atEi5ubm69957tWXLFt1+++2KjY3V2LFjrTe+DqzaAQAAEKEWLlyotLQ0xcfHKyMjQ5s3bw5Yd8iQIXK5XDXK1Vdf7aszbty4Gt8PHz68MR4FABokISHBrwRKur1ery688ELNmTNH/fr108SJEzVhwgQVFBTY1jZ6ugEE5JVbHhZSAwBTqpNVs+eYtWLFCuXm5qqgoEAZGRnKz89Xdna2SkpKlJSUVKP+n//8Z1VVVfk+f/311+rTp49GjhzpV2/48OF+cx0DvbgCQLA1Rvzs0KFDjb3KzzvvPL3yyiumrmMGSTeAgKxsAeZhmQgAUc7ldsltcnikYWF4+YIFCzRhwgTf6tgFBQV67bXXtGTJEk2dOrVG/TZt2vh9Xr58uZo3b14j6Y6Li2NvaQAh0Rjxc9CgQSopKfE79umnn6pz586mrmMGw8sBBOSV21IBgGjmcrl88xLrXb7rqSkvL/crgfbUraqqUnFxsbKysnzH3G63srKyVFRUVK92PvXUUxo1apTOOOMMv+OFhYVKSkpS9+7d9etf/1pff/21xV8JADCnIfGzvu666y69++67mjNnjrZv365ly5Zp8eLFmjRpkk1P5fCku7KyUjNnzgz7TeCt4NkiU6Q9m8dwWSqIfJH2Z9UMni0yRdKzmX5h/N7CQampqUpMTPSVvLy8Wu9x4MABeTyeGttRtW/f3rfXcF02b96sjz76SL/85S/9jg8fPlzPPvus1q5dq7lz52r9+vW68sor5fF4LP5qRJdI+nNqFs8WuSLp+RoSP+vroosu0sqVK/Xiiy+qV69emj17tvLz8zV69GibnsrhW4ZVLz3vxO03eLbIFCnPVt3Op//ZR81Nbhl27IhH4/r9K+yfEXWLlD+rVvBskSkSnq26jd1vXa6YOHNb3ngqj6nkj6NqXX23tjnVe/bsUceOHfXOO+8oMzPTd/yee+7R+vXrtWnTpjrv96tf/UpFRUX64IMP6qz3xRdf6Oyzz9bbb7+toUOHmnqmaBQJf06t4tkiVyQ8XzDiZzg/n6N7ugE0jNdwWyoAEM0a0lNT39V327Ztq5iYGJWVlfkdLysrO+187IqKCi1fvlw333zzaZ+la9euatu2rbZv317PpwcA6xqjpzsUeDsGAACIMLGxsUpPT9fatWt9x7xer9auXevX812bl156SZWVlbrppptOe5///Oc/+vrrr9WhQ4cGtxkAolWjr17u9Xq1Z88etWzZ0tL2GGaUl5f7/dtJeLbI1NjPZhiGjhw5opSUFLnd5n/G5rGwZZiHLcNs0ZixU+LvYaTi2YKjobHTSs+LlZ6a3NxcjR07Vv3799eAAQOUn5+viooK32rmY8aMUceOHWvMC3/qqac0YsQInXnmmX7Hjx49qgceeEDXXXedkpOT9fnnn+uee+5Rt27dlJ2dbbp94YJ3z+Dg2SIX8TP0Gj3p3rNnj1JTUxv1no19v8bEs0Wmxn62Xbt2qVOnTqbP80qmF0bzmr4L6iMUsVPi72Gk4tmCw2rsdDfSlmHXX3+99u/fr+nTp6u0tFR9+/bV6tWrfYur7dy5s8ZLb0lJiTZu3Ki33nqrxvViYmL0wQcf6JlnntGhQ4eUkpKiYcOGafbs2RG9VzfvnsHFs0Uu4mfoNHrS3bJlS0nSV++nKaGF80a3X9u9d6ibYB/nrrnnWCd1Qhv1uu/vnVlWtgBjyzB7VP8exvT8mVwxTUPcmuDbveaRUDfBNk6PnOH/qmPekSNH1O2ccyzHTpf7VDF7jhU5OTnKycmp9bvCwsIax7p3765Aa+g2a9ZMb775prWGhLHq38fPPvvM8u9pOPM6OMicNWxyqJtgq+JLToS6CUF3tOqEBj25MiLiZ2Nq9KS7elhPQgu3ElpGwK+QSU1cznsZ/i8HR3Wn+u63zOpwOo/hlsfkwmhm66N+qn8PXTFN5YqJDXFrgi9cVxsNBqdHTicm3dWsxk6Xy/y+sY0xbSRaVf/atmzZ0pGxxslJtxP/f/d9LSN3AMlpET/9NXrSDSByeOWS1+Qrtdn6AOA0brcsDI+0qTEAEEGcGj8joIkAAAAAAEQmeroBBMTwcgAwz6mr7wKA3ZwaP0m6AQRkbcswkm4A0c3lsvDSGAFzEgHAbk6NnyTdAALyGi55zW4ZZrI+ADiN2+WS2+RLoBEBL40AYDenxk+SbgABeS30dLNlGICoZ2F4pCJgeCQA2M6h8ZOkG0BAXsMtr8k52mbrA4DTOHVOIgDYzanxk7djAAAAAABsQk83gIA8csljct9ts/UBwGncbpfpfWbN1gcAJ3Jq/KSnG0BA1cPLzRYrFi5cqLS0NMXHxysjI0ObN2+us35+fr66d++uZs2aKTU1VXfddZeOHz9u6d4AEEwul8tSAYBo59T4SU83gIA8Mt9z7bFwnxUrVig3N1cFBQXKyMhQfn6+srOzVVJSoqSkpBr1ly1bpqlTp2rJkiUaOHCgPv30U40bN04ul0sLFiyw0AIACB6X+1Qxew4ARDunxs8IaCKAUGmsnu4FCxZowoQJGj9+vHr27KmCggI1b95cS5YsqbX+O++8o0GDBunGG29UWlqahg0bphtuuOG0veMA0Biqh0eaLQAQ7ZwaP0m6AQTkMdyWiiSVl5f7lcrKylrvUVVVpeLiYmVlZfmOud1uZWVlqaioqNZzBg4cqOLiYl+S/cUXX+j111/XVVddFeRfAQAwr3r1XbMFAKKdU+MnSTcAW6SmpioxMdFX8vLyaq134MABeTwetW/f3u94+/btVVpaWus5N954o2bNmqXBgweradOmOvvsszVkyBDde++9QX8OAAAAoCGY0w0gIEMueU3O6Ta+q79r1y4lJCT4jsfFxQWtXYWFhZozZ47++Mc/KiMjQ9u3b9cdd9yh2bNn6/777w/afQDACisL+0TCQkAAYDenxk+SbgABfX+4uJlzJCkhIcEv6Q6kbdu2iomJUVlZmd/xsrIyJScn13rO/fffr5///Of65S9/KUm64IILVFFRoYkTJ+q3v/2t3G4G8QAIHadueQMAdnNq/OTNFEBAXsNlqZgRGxur9PR0rV279r/39Xq1du1aZWZm1nrOsWPHaiTWMTExkiTDMEw+JQAEl8tlYU5iBPTUAIDdnBo/6ekGEJBHbnlM/mzObH1Jys3N1dixY9W/f38NGDBA+fn5qqio0Pjx4yVJY8aMUceOHX3zwq+55hotWLBA/fr18w0vv//++3XNNdf4km8ACJUYt0sxJntejAjoqQEAuzk1fpJ0AwjISs+12fqSdP3112v//v2aPn26SktL1bdvX61evdq3uNrOnTv9erbvu+8+uVwu3Xfffdq9e7fatWuna665Rg8++KDpewNAsLktvDR6I+ClEQDs5tT4SdINICCv3PKa7Lk2W79aTk6OcnJyav2usLDQ73OTJk00Y8YMzZgxw9K9AMBOVnpqIuGlEQDs5tT4yZxuAAAAAABsYinpXrhwodLS0hQfH6+MjAxt3rw52O0CEAY8hstSQWDET8D5qntqzBYERuwEooNT46fppHvFihXKzc3VjBkz9P7776tPnz7Kzs7Wvn377GgfgBBqjNXLownxE4gOTn1pDBViJxA9nBo/TSfdCxYs0IQJEzR+/Hj17NlTBQUFat68uZYsWWJH+wCEkGG45TVZDJP7ekcT4icQHZq4pSZul8kS6laHL2InED0aO34+9NBDcrlcuvPOO4P2DLUxtZBaVVWViouLNW3aNN8xt9utrKwsFRUV1XpOZWWlKisrfZ/Ly8stNhVAY/PIJY/M/fTQbP1oYTZ+EjuByOXUhYBCgXdPILo0ZvzcsmWLnnjiCfXu3dvS+WaY+rnAgQMH5PF4fNv4VGvfvr1KS0trPScvL0+JiYm+kpqaar21ABqV17AyxDzUrQ5PZuMnsROIXNVb3pgpbpLuWvHuCUSXxoqfR48e1ejRo/Xkk0+qdevWNjyJP9sHM02bNk2HDx/2lV27dtl9SwCIeMROALCG+AlEp/Lycr/y/REvPzRp0iRdffXVysrKapS2mUq627Ztq5iYGJWVlfkdLysrU3Jycq3nxMXFKSEhwa8AiAxm53NXF9RkNn4SO4HIFeNyK8ZtsrisxU4zq3o//fTTcrlcfiU+Pt6vjmEYmj59ujp06KBmzZopKytLn332maW2BQPvnkB0aUj8TE1N9RvlkpeXV+s9li9frvfffz/g93YwFeFjY2OVnp6utWvX+o55vV6tXbtWmZmZQW8cgNDyymWpoCbiJxA9Gmv1XSureickJGjv3r2+8tVXX/l9//DDD+uxxx5TQUGBNm3apDPOOEPZ2dk6fvy46fYFA7ETiC4NiZ+7du3yG+Xy/bUgqu3atUt33HGHXnjhhRo/dLSTqYXUJCk3N1djx45V//79NWDAAOXn56uiokLjx4+3o30AQsjKvtvs0x0Y8ROIDlaS6Or6P1z0Ky4uTnFxcbWe8/1VvSWpoKBAr732mpYsWaKpU6fWeo7L5QrYQ2wYhvLz83XffffpJz/5iSTp2WefVfv27bVq1SqNGjXK1DMFC7ETiB4NiZ/1GdlSXFysffv26cILL/Qd83g82rBhg/7whz+osrJSMTEx5ht+GqaT7uuvv1779+/X9OnTVVpaqr59+2r16tU1FrgAEPmsDBdneHlgxE8gOjTkpfGHi37NmDFDM2fOrFHfyqre0qnFgzp37iyv16sLL7xQc+bM0fnnny9J+vLLL1VaWuo3xzExMVEZGRkqKioKWdJN7ASiR0PiZ30MHTpUH374od+x8ePHq0ePHpoyZYotCbdkIemWpJycHOXk5AS7LQDCjFenViQ3ew4CI34CzhfjcinGZfKl0fXf4ZHf76kJ1Mtd16re27Ztq/Wc7t27a8mSJerdu7cOHz6s+fPna+DAgfr444/VqVMn32rgZlYKbyzETiA6NCR+1kfLli3Vq1cvv2NnnHGGzjzzzBrHg8lS0g0AAIDgs3Phr8zMTL950AMHDtR5552nJ554QrNnz7blngAAkm4AdTAsLIxm0NMNIMq5LQyPNLvPrJVVvX+oadOm6tevn7Zv3y5JvvPKysrUoUMHv2v27dvXVPsAwIrGiJ8/VFhY2KDz64PJlwAC8houSwUAolljrF4ejFW9PR6PPvzwQ1+C3aVLFyUnJ/tds7y8XJs2bWKlcACNorF2f2hs9HQDCIiF1ADAvCZul5qYfAn0WHhpPN2q3mPGjFHHjh19e9HOmjVLP/rRj9StWzcdOnRI8+bN01dffaVf/vKXkk6tbH7nnXfqd7/7nc455xx16dJF999/v1JSUjRixAjT7QMAsxorfjY2km4AAVnpuaanG0C0s3v13WqnW9V7586dcrv/+4PQb775RhMmTFBpaalat26t9PR0vfPOO+rZs6evzj333KOKigpNnDhRhw4d0uDBg7V69epG3c8WQPRqrPjZ2Ei6AQTktTCnm9XLAUS7xnxprGtV7x/OU/z973+v3//+93Vez+VyadasWZo1a5al9gBAQzg16WYcKAAAAAAANqGnG0BADC8HAPNiXBZ6akzuSwsATuTU+EnSDSAgkm4AMC8UW94AgBM4NX6SdAMIiKQbAMxz6pxEALCbU+MnSTeAgEi6AcA8p740AoDdnBo/SboBBGTI/Grkhj1NAYCIEeM2/xIYw9K2AODY+EnSDSAgeroBwDyn9tQAgN2cGj8j4OcCAAAAAABEJnq6AQRETzcAmOfUnhoAsJtT4ydJN4CASLoBwDynbnkDAHZzavwk6QYQEEk3AJgX43IpxmWyp8ZkfQBwIqfGT5JuAAEZhkuGySTabH0AcBq3yyW3yZdAs/UBwImcGj9JugEE5JXL9JZhZusDgNPESIoxGQpjbGkJAEQWp8ZPVi8HAAAAAMAmIevpvrZ7bzVxNQ3V7W3z5u5/hroJtslO6RvqJqCRMac7/Oxe84gSEhJC3YygSxg4KdRNsE35OwtD3QRbGaFugA0a+kxut8v0wj6RsBBQpHMZXrkMb6ibEXRul3P70HZcFxfqJtgq7ZVQtyD4DE/Dzndq/GR4OYCAmNMNAOY5dSEgALCbU+MnSTeAgOjpBgDznLoQEADYzanxk6QbQED0dAOAeW6X+YWAImB0JADYzqnxk6QbQECGhZ5ukm4A0c6pcxIBwG5OjZ/OXXkBAAAAAIAQo6cbQECGJMPkMr5OXMkYAMxw6pxEALCbU+MnSTeAgLxyySWTC6mZrA8AThNjYU6i2foA4EROjZ8k3QACYiE1ADDPqT01AGA3p8ZPkm4AAXkNl1xsGQYApsS4XYoxubCP2foA4EROjZ8k3QACMgwLc7qZ1A0gyjm1pwYA7ObU+Mnq5QAAAAAA2ISkG0BA1XO6zRYAiGbVCwGZLQAQ7Rojfubl5emiiy5Sy5YtlZSUpBEjRqikpMSeB/oOSTeAgEi6AcA813fDI80Ul8XhkQsXLlRaWpri4+OVkZGhzZs3B6z75JNP6uKLL1br1q3VunVrZWVl1ag/btw4ub5rT3UZPny4pbYBgFmNET/Xr1+vSZMm6d1339WaNWt04sQJDRs2TBUVFTY9FXO6AdSBhdQAwLzGWghoxYoVys3NVUFBgTIyMpSfn6/s7GyVlJQoKSmpRv3CwkLdcMMNGjhwoOLj4zV37lwNGzZMH3/8sTp27OirN3z4cC1dutT3OS4uznTbAMCKhsTP8vJyv+NxcXG1xq/Vq1f7fX766aeVlJSk4uJiXXLJJSZbXD/0dAMIqHohNbMFAKKZW5LbZbJYuM+CBQs0YcIEjR8/Xj179lRBQYGaN2+uJUuW1Fr/hRde0K233qq+ffuqR48e+tOf/iSv16u1a9f61YuLi1NycrKvtG7d2kLrAMC8hsTP1NRUJSYm+kpeXl697nn48GFJUps2bex5KNHTDaAOp5Jos/t029QYAIgQMS6XYkwOd6yuX9+emqqqKhUXF2vatGm+Y263W1lZWSoqKqrXPY8dO6YTJ07UeNEsLCxUUlKSWrdurcsvv1y/+93vdOaZZ5p6HgCwoiHxc9euXUpISPAdr88oHa/XqzvvvFODBg1Sr169zDXWBJJuAAFZmaPNnG4A0a4hW96kpqb6HZ8xY4ZmzpxZo/6BAwfk8XjUvn17v+Pt27fXtm3b6nXPKVOmKCUlRVlZWb5jw4cP1//7f/9PXbp00eeff657771XV155pYqKihQTE2PqmQDArIbEz4SEBL+kuz4mTZqkjz76SBs3bjR1nlkk3QAAAGHCSk+NFQ899JCWL1+uwsJCxcfH+46PGjXK998XXHCBevfurbPPPluFhYUaOnSoLW0BgFDIycnRq6++qg0bNqhTp0623os53QACMiwWK8yswCtJhw4d0qRJk9ShQwfFxcXp3HPP1euvv27x7gAQPDFua0X6b09NdQmUdLdt21YxMTEqKyvzO15WVqbk5OQ62zd//nw99NBDeuutt9S7d+8663bt2lVt27bV9u3b6/8LAAAWNSR+1pdhGMrJydHKlSu1bt06denSxZ6H+R6SbgABNdaWYdUr8M6YMUPvv/+++vTpo+zsbO3bt6/W+lVVVbriiiu0Y8cOvfzyyyopKdGTTz7pt/ouAITKqcV9zG57Y+4esbGxSk9P91sErXpRtMzMzIDnPfzww5o9e7ZWr16t/v37n/Y+//nPf/T111+rQ4cO5hoIABY0RvycNGmSnn/+eS1btkwtW7ZUaWmpSktL9e2339rzUGJ4OYC6WOm6ttDV/f0VeCWpoKBAr732mpYsWaKpU6fWqL9kyRIdPHhQ77zzjpo2bSpJSktLM39jALCB28JCQGbnMEpSbm6uxo4dq/79+2vAgAHKz89XRUWFL5aOGTNGHTt29K3gO3fuXE2fPl3Lli1TWlqaSktLJUktWrRQixYtdPToUT3wwAO67rrrlJycrM8//1z33HOPunXrpuzsbNPtAwCzGiN+Llq0SJI0ZMgQv+NLly7VuHHjTF2rvki6AQRmpefasH8F3r/+9a/KzMzUpEmT9Je//EXt2rXTjTfeqClTprDQD4CQa8hCQGZcf/312r9/v6ZPn67S0lL17dtXq1ev9i2utnPnTrnd/x3UuGjRIlVVVemnP/2p33WqF2uLiYnRBx98oGeeeUaHDh1SSkqKhg0bptmzZ7NXN4BG0Rjx0wjBVjsk3QACsrLvdnV9O1fg/eKLL7Ru3TqNHj1ar7/+urZv365bb71VJ06c0IwZM8w1GACCzMocQ7P1q+Xk5CgnJ6fW7woLC/0+79ixo85rNWvWTG+++aa1hgBAEDRm/GxMJN0AbGHnCrxer1dJSUlavHixYmJilJ6ert27d2vevHkk3QAAAAgrpn8usGHDBl1zzTVKSUmRy+XSqlWrbGgWgHDQkIXU7FyBt0OHDjr33HP9hpKfd955Ki0tVVVVVZCePriInUD0ML8IkPnhlNGE+AlED6fGT9NJd0VFhfr06aOFCxfa0R4A4cRwWSsmWFmBd9CgQdq+fbu8Xq/v2KeffqoOHTooNjbW2rPajNgJRA+Xy1pB7YifQPRwavw0Pbz8yiuv1JVXXlnv+pWVlaqsrPR9/uHiSgDCV0PmdJthdgXeX//61/rDH/6gO+64Q7fddps+++wzzZkzR7fffrv5mzcSYicQPdxyyS2TCwGZrB9NiJ9A9HBq/LR9TndeXp4eeOABu28DwA6NtGWY2RV4U1NT9eabb+quu+5S79691bFjR91xxx2aMmWK+ZuHKWInELms9LxEQk9NpCB+ApHLqfHT9qR72rRpys3N9X0uLy+vsaoxgPBkWNgyzPQWY98xswKvJGVmZurdd9+1dK9IQOwEIpfbdaqYPQfBQfwEIpdT46ftSXegvXkBAIEROwHAGuIngHDDlmEA6mZhuDgARDOnDo8EALs5NX6SdAMIqDGHlwOAUzh1ISAAsJtT46fppPvo0aPavn277/OXX36prVu3qk2bNjrrrLOC2jgAIdZIC6lFA2InEEWsbGET/u+MIUP8BKKIQ+On6aT7vffe02WXXeb7XL1QxdixY/X0008HrWEAwoFL5iNZBES+ECB2AtHDqQsBhQrxE4geTo2fppPuIUOGyLCyES+AyENPd9AQO4HowY8rg4v4CUQPp8ZP9+mrAAAAAAAAK1hIDUBg9HQDgGlul0tuk5MSzdYHACdyavwk6QYQmOE6VcyeAwBRzCULW97Y0hIAiCxOjZ8k3QACMoxTxew5ABDN3DI/f4/5fgDg3PhJ0g0gMIaXA4BpLpdLLpNdNWbrA4ATOTV+knQDCIzh5QBgmlO3vAEAuzk1fpJ0AwjIZZwqZs8BgGjmclmYkxgBL40AYDenxs9IGAIPAAAAAEBEoqcbQGDM6QYA05y6EBAA2M2p8ZOkG0BgzOkGANOcuhAQANjNqfGTpBtAYPR0A4BpTl0ICADs5tT4SdINIDCSbgCwJALeAQEgLDkxfpJ0AwiMpBsATHNqTw0A2M2p8TMS5p0DAAAAABCR6OkGEBgLqQGAaU5dCAgA7ObU+EnSDSAgl3GqmD0HAKKZU4dHAoDdnBo/GV4OIDDDYgGAKOayWKxYuHCh0tLSFB8fr4yMDG3evLnO+i+99JJ69Oih+Ph4XXDBBXr99df9vjcMQ9OnT1eHDh3UrFkzZWVl6bPPPrPYOgAwJ5zjZ0OQdAMAAASR2+WyVMxasWKFcnNzNWPGDL3//vvq06ePsrOztW/fvlrrv/POO7rhhht0880365///KdGjBihESNG6KOPPvLVefjhh/XYY4+poKBAmzZt0hlnnKHs7GwdP37c8q8HANRXuMbPhiLpBhCQS/8dYl7vEupGA0CIuVzWilkLFizQhAkTNH78ePXs2VMFBQVq3ry5lixZUmv9Rx99VMOHD9fdd9+t8847T7Nnz9aFF16oP/zhD5JO9XLn5+frvvvu009+8hP17t1bzz77rPbs2aNVq1Y14FcEAOonXONnQ4VuTrfhzHGo2Sl9Q90E27y5Z2uom2Cr7I79Qt0EG7ic+Ncsqjkzckrl7ywMdRNskzBwUqibYCsn/t6F8oeH5eXlfp/j4uIUFxdXo15VVZWKi4s1bdo03zG3262srCwVFRXVeu2ioiLl5ub6HcvOzvYl1F9++aVKS0uVlZXl+z4xMVEZGRkqKirSqFGjrD5WWJjaIUOxDuxvavLyX0LdBNvMm7wg1E2wVXmuN9RNCLry8nK17/BCyO79fcGMnw3lvMgDIHiqVy83WwAgirkMw1KRpNTUVCUmJvpKXl5erfc4cOCAPB6P2rdv73e8ffv2Ki0trfWc0tLSOutX/9vMNQEgmMI1fjYUq5cDCMxKt6oTu2EBwAzDe6qYPUfSrl27lJCQ4DtcWy8NADiWQ+MnSTeAwEi6AcA0l+GVy+RLY3X9hIQEv5fGQNq2bauYmBiVlZX5HS8rK1NycnKt5yQnJ9dZv/rfZWVl6tChg1+dvn371vtZAMCqcI2fDcXwcgABmV5EzcK+3gDgONU9NWaLCbGxsUpPT9fatWt9x7xer9auXavMzMxaz8nMzPSrL0lr1qzx1e/SpYuSk5P96pSXl2vTpk0BrwkAQRWm8bOh6OkGEBg93QBgnmF8t2CsyXNMys3N1dixY9W/f38NGDBA+fn5qqio0Pjx4yVJY8aMUceOHX3zGu+44w5deumleuSRR3T11Vdr+fLleu+997R48WJJksvl0p133qnf/e53Ouecc9SlSxfdf//9SklJ0YgRI0y3DwBMC5P4GWwk3QAAABHo+uuv1/79+zV9+nSVlpaqb9++Wr16tW9xoJ07d8rt/u+gxoEDB2rZsmW67777dO+99+qcc87RqlWr1KtXL1+de+65RxUVFZo4caIOHTqkwYMHa/Xq1YqPj2/05wMAu5wufgYbSTeAwOjpBgDzGrAQkFk5OTnKycmp9bvCwsIax0aOHKmRI0cGvJ7L5dKsWbM0a9YsS+0BgAYJk/gZbCTdAAKyMkebOd0Aot2pLWzMLgRE8AQAp8ZPkm4AgVnZd5t9ugFEu0bsqQEAR3Fo/CTpBhAYw8sBwDyHvjQCgO0cGj9JugEExPByALDAoS+NAGA7h8ZPkm4AgdHTDQDmGV7J67yXRgCwnUPjp/v0VQAAAAAAgBX0dAMIzMLwcnq6AUQ7l+G1sPpu+PfUAIDdnBo/SboBBMbwcgAwz6FzEgHAdg6NnyTdAAIj6QYA8wzjVDF7DgBEO4fGT5JuAAGxejkAWODQnhoAsJ1D4ydJNwAAQBC5DMPCnER+YgkATo2frF4OAAAAAIBN6OkGEBhzugHAPIcOjwQA2zk0fpJ0AwiIOd0AYIFDXxoBwHYOjZ8k3QDqRhINAOY49KURAGzn0PhJ0g0gMIaXA4BpLsNrYSGg8H9pBAC7OTV+knQDCIjh5QBggdd7qpg9BwCinUPjp6nVy/Py8nTRRRepZcuWSkpK0ogRI1RSUmJX2wDAMYifAGAesROAE5hKutevX69Jkybp3Xff1Zo1a3TixAkNGzZMFRUVdrUPQCgZFosFCxcuVFpamuLj45WRkaHNmzfX67zly5fL5XJpxIgR1m7cSIifQBQxDGsFNRA7gSjj0Phpanj56tWr/T4//fTTSkpKUnFxsS655JJaz6msrFRlZaXvc3l5uYVmAgiFxhpevmLFCuXm5qqgoEAZGRnKz89Xdna2SkpKlJSUFPC8HTt26De/+Y0uvvhi8zdtZGbjJ7ETiGAOXQgoFHj3BKKMQ+OnqZ7uHzp8+LAkqU2bNgHr5OXlKTEx0VdSU1MbcksAjakBPd3l5eV+5fsvQD+0YMECTZgwQePHj1fPnj1VUFCg5s2ba8mSJQHP8Xg8Gj16tB544AF17do1CA/buE4XP4mdQOSqXgjIbMHp8e4JOJtT46flpNvr9erOO+/UoEGD1KtXr4D1pk2bpsOHD/vKrl27rN4SQGNrQNKdmprq99KTl5dX6y2qqqpUXFysrKws3zG3262srCwVFRUFbNqsWbOUlJSkm2++uaFP2ejqEz+JnUAEq+6pMVtQJ949gSjg0PhpefXySZMm6aOPPtLGjRvrrBcXF6e4uDirtwEQQg0ZXr5r1y4lJCT4jgeKAwcOHJDH41H79u39jrdv317btm2r9ZyNGzfqqaee0tatW801LkzUJ34SO4EIZhgWhkeG/5zEUOPdE4gCDo2flpLunJwcvfrqq9qwYYM6deoU7DYBcICEhAS/pDtYjhw5op///Od68skn1bZt26Bf327ETwAwj9gJIJKZSroNw9Btt92mlStXqrCwUF26dLGrXQDCgZXVyE3Wb9u2rWJiYlRWVuZ3vKysTMnJyTXqf/7559qxY4euueYa3zHvd/szNmnSRCUlJTr77LNNNtp+xE8gihgeyesxfw5qIHYCUcah8dNU0j1p0iQtW7ZMf/nLX9SyZUuVlpZKkhITE9WsWTNbGggghBoh6Y6NjVV6errWrl3r2/bL6/Vq7dq1ysnJqVG/R48e+vDDD/2O3XfffTpy5IgeffTRsF0wh/gJRA/D65XhNTc80mz9aEHsBKKLU+OnqaR70aJFkqQhQ4b4HV+6dKnGjRsXrDYBCBONtWVYbm6uxo4dq/79+2vAgAHKz89XRUWFxo8fL0kaM2aMOnbsqLy8PMXHx9dYQKdVq1aSVOfCOqFG/ASiiNdCT43Z+lGC2AlEGYfGT9PDywFEkUbo6Zak66+/Xvv379f06dNVWlqqvn37avXq1b7F1Xbu3Cm3u0E7HIYc8ROIIg59aQwFYicQZRwaPyP7LRaArap7us0WK3JycvTVV1+psrJSmzZtUkZGhu+7wsJCPf300wHPffrpp7Vq1SprNwaAIDM8HkvFTgcPHtTo0aOVkJCgVq1a6eabb9bRo0frrH/bbbepe/fuatasmc466yzdfvvtvn2yq7lcrhpl+fLltj4LAOcKx/gZDJa3DAMQBRqppxsAHMXrPVXMnmOj0aNHa+/evVqzZo1OnDih8ePHa+LEiVq2bFmt9ffs2aM9e/Zo/vz56tmzp7766ivdcsst2rNnj15++WW/ukuXLtXw4cN9n6un/ACAaWEYP4OBpBsAACBMlJeX+30Oxp7Tn3zyiVavXq0tW7aof//+kqTHH39cV111lebPn6+UlJQa5/Tq1UuvvPKK7/PZZ5+tBx98UDfddJNOnjypJk3++wrZqlWrWnebAIBItmPHDs2ePVvr1q1TaWmpUlJSdNNNN+m3v/2tYmNjTV2L4eUAAjMsFgCIZl7vf+cl1ruc6qlJTU1VYmKir+Tl5TW4OUVFRWrVqpUv4ZakrKwsud1ubdq0qd7XOXz4sBISEvwSbunUCuNt27bVgAEDtGTJEuZhA7CuAfEz2LZt2yav16snnnhCH3/8sX7/+9+roKBA9957r+lr0dMNICDXd8XsOQAQzQyvR4bJhX2q6+/atUsJCQm+4w3t5Zak0tJSJSUl+R1r0qSJ2rRp49uC63QOHDig2bNna+LEiX7HZ82apcsvv1zNmzfXW2+9pVtvvVVHjx7V7bff3uB2A4g+DYmfwR4pNHz4cL+pM127dlVJSYkWLVqk+fPnm7oWSTeAwJjTDQDmGRbmJBqn6ickJPgl3XWZOnWq5s6dW2edTz75xFw7alFeXq6rr75aPXv21MyZM/2+u//++33/3a9fP1VUVGjevHkk3QCsaUD8TE1N9Ts8Y8aMGjGroQ4fPqw2bdqYPo+kG0BAjbVPNwA4SUN6asyYPHnyafeq7tq1q5KTk7Vv3z6/4ydPntTBgwdPOxf7yJEjGj58uFq2bKmVK1eqadOmddbPyMjQ7NmzVVlZGZReegDRJdxGCn3f9u3b9fjjj5vu5ZZIugHUhZ5uADCvkfaZbdeundq1a3faepmZmTp06JCKi4uVnp4uSVq3bp28Xq/f9ow/VF5eruzsbMXFxemvf/2r4uPjT3uvrVu3qnXr1iTcAKxpQPys70ih+o4S6tGjh+/z7t27NXz4cI0cOVITJkww1z6RdAMAADjaeeedp+HDh2vChAkqKCjQiRMnlJOTo1GjRvlWLt+9e7eGDh2qZ599VgMGDFB5ebmGDRumY8eO6fnnn1d5eblvvmS7du0UExOjv/3tbyorK9OPfvQjxcfHa82aNZozZ45+85vfhPJxAaBO9R0lVG3Pnj267LLLNHDgQC1evNjSPUm6AdSNnmsAMCcM95l94YUXlJOTo6FDh8rtduu6667TY4895vv+xIkTKikp0bFjxyRJ77//vm9l827duvld68svv1RaWpqaNm2qhQsX6q677pJhGOrWrZsWLFhgqRcIACQ1Svys7ygh6dQPJC+77DKlp6dr6dKlcrutbf5F0g0gIOZ0A4B5hscjw2NyTqLJ+ma1adNGy5YtC/h9Wlqa31ZfQ4YMOe3WXz9c2RcAGiqc4ufu3bs1ZMgQde7cWfPnz9f+/ft9351uPYwfIukGEBhzugHAvOp9Zs2eAwDRLozi55o1a7R9+3Zt375dnTp18vvudD+U/CFr/eMAokJ1T7fZAgBRrXohILMFAKJdGMXPcePGyTCMWotZ9HQDCIyebgAwzfB6ZZjseTFbHwCcyKnxk55uAAAAAABsQk83gIBYSA0ALGikfboBwHEcGj9JugEExvByADDPsPDSaIT/SyMA2M6h8ZOkG0BgJN0AYJpT5yQCgN2cGj9JugEExPByALAgjLa8AYCI4tD4SdINIDB6ugHAPIfOSQQA2zk0fpJ0o96yO/YLdRNs9ebuf4a6CUFXfsSr1ueGuhUIJtd3xWmc/LOa8ncWhroJtkoYOCnUTQg6w1MV6ibABuWLnlHTZi1C3YygS/zpT0LdBNt4Kz4JdRNs5XY5byMpw4HPFAwk3QACchmGXIa5dMhsfQBwGsPjkeEx1/Nitj4AOJFT4ydJN4DAGF4OAOZ5vebnGEbAnEQAsJ1D4ydJN4CAWEgNACxw6JxEALCdQ+MnSTeAwOjpBgDTDK9HhsmXQLP1AcCJnBo/SboBBERPNwCY59R9ZgHAbk6NnywvBwAAAACATejpBhAYw8sBwDTDa8jwmO2pIXgCgFPjJ0k3gIAYXg4A5hker/mXRpP1AcCJnBo/SboBBEZPNwCY5tQ5iQBgN6fGT5JuAHWi5xoAzHFqTw0A2M2p8ZOkG0BghnGqmD0HAKKYU18aAcBuTo2fJN0AAmJONwCYZ3g88npM7jNrsj4AOJFT4ydbhgEAAAAAYBN6ugEExkJqAGCaYVhYCMgI/+GRAGA3p8ZPkm4AAbm8p4rZcwAgmjl1TiIA2M2p8ZOkG0Bg9HQDgGlOfWkEALs5NX6SdAMIiIXUAMA8w2tY2GeW4AkATo2fLKQGILDqLcPMFgCIYl6P11Kx08GDBzV69GglJCSoVatWuvnmm3X06NE6zxkyZIhcLpdfueWWW/zq7Ny5U1dffbWaN2+upKQk3X333Tp58qSdjwLAwcIxfgYDPd0AAAAON3r0aO3du1dr1qzRiRMnNH78eE2cOFHLli2r87wJEyZo1qxZvs/Nmzf3/bfH49HVV1+t5ORkvfPOO9q7d6/GjBmjpk2bas6cObY9CwBEGpJuAAExvBwAzAu3OYmffPKJVq9erS1btqh///6SpMcff1xXXXWV5s+fr5SUlIDnNm/eXMnJybV+99Zbb+nf//633n77bbVv3159+/bV7NmzNWXKFM2cOVOxsbG2PA8A5wq3+BksDC8HEJhhsQBAFKt+aTRbJKm8vNyvVFZWNrg9RUVFatWqlS/hlqSsrCy53W5t2rSpznNfeOEFtW3bVr169dK0adN07Ngxv+tecMEFat++ve9Ydna2ysvL9fHHHze43QCiT0PiZzgj6QYQUHVPt9kCANGsep9ZU+W7fWZTU1OVmJjoK3l5eQ1uT2lpqZKSkvyONWnSRG3atFFpaWnA82688UY9//zz+vvf/65p06bpueee00033eR33e8n3JJ8n+u6LgAE0pD4aafKykr17dtXLpdLW7duNX0+w8sBBGZlYTQWUgMQ5RoyPHLXrl1KSEjwHY+Liwt4ztSpUzV37tw6r/vJJ5+Yasf3TZw40fffF1xwgTp06KChQ4fq888/19lnn235ugAQSLgOL7/nnnuUkpKif/3rX5bON9XTvWjRIvXu3VsJCQlKSEhQZmam3njjDUs3BhD+6OkOHuInED0aMjyyOkZUl7qS7smTJ+uTTz6ps3Tt2lXJycnat2+f37knT57UwYMHA87Xrk1GRoYkafv27ZKk5ORklZWV+dWp/mzmunUhdgLRJRyHl7/xxht66623NH/+fMvXMNXT3alTJz300EM655xzZBiGnnnmGf3kJz/RP//5T51//vmWGwEATkf8BBBs7dq1U7t27U5bLzMzU4cOHVJxcbHS09MlSevWrZPX6/Ul0vVRPaSyQ4cOvus++OCD2rdvn2/4+po1a5SQkKCePXuafJraETsB1Fd5ebnf57i4uDp/cFkfZWVlmjBhglatWuW3e4NZpnq6r7nmGl111VU655xzdO655+rBBx9UixYt9O677wY8p7KyssaiIAAiBAupBY3Z+EnsBCKX1+u1VOxy3nnnafjw4ZowYYI2b96s//u//1NOTo5GjRrlW7l89+7d6tGjhzZv3ixJ+vzzzzV79mwVFxdrx44d+utf/6oxY8bokksuUe/evSVJw4YNU8+ePfXzn/9c//rXv/Tmm2/qvvvu06RJkxr8oluNd08gujQkfgZ7TQzDMDRu3DjdcsstfgtRWmF5ITWPx6Ply5eroqJCmZmZAevl5eX5PXxqaqrVWwJoZAwvt0d94iexE4hc4Tg88oUXXlCPHj00dOhQXXXVVRo8eLAWL17s+/7EiRMqKSnxrU4eGxurt99+W8OGDVOPHj00efJkXXfddfrb3/7mOycmJkavvvqqYmJilJmZqZtuukljxozx29c7mHj3BJyvIfFz165dOnz4sK9Mmzat1ntMnTpVLperzrJt2zY9/vjjOnLkSMDrmGF6IbUPP/xQmZmZOn78uFq0aKGVK1fWOYRo2rRpys3N9X0uLy8n+AGRwmucKmbPQa3MxE9iJxC5Tr0EekyfY6c2bdpo2bJlAb9PS0uT8b2FMFNTU7V+/frTXrdz5856/fXXg9LGQHj3BKJHQ+Jn9doPpzN58mSNGzeuzjpdu3bVunXrVFRUVGPkTv/+/TV69Gg988wz9W6j6aS7e/fu2rp1qw4fPqyXX35ZY8eO1fr16wMGv2CMpQcQIlaGi5NzB2QmfhI7gchVvY2N2XNQO949gejRGPGzvuthPPbYY/rd737n+7xnzx5lZ2drxYoVptbDkCwk3bGxserWrZskKT09XVu2bNGjjz6qJ554wuylAIQ5l8wPF3fZ0hJnIH4C0cHwWtjyhqQ7IGInED3CKX6eddZZfp9btGghSTr77LPVqVMnU9eyPKe7mtfrVWVlZUMvAwBRh/gJAOYROwFEGlNJ97Rp07Rhwwbt2LFDH374oaZNm6bCwkKNHj3arvYBCCXDsFYsWLhwodLS0hQfH6+MjAzfCrq1efLJJ3XxxRerdevWat26tbKysuqsHw6In0AUsbIIkM1zuiMVsROIMmEcP6vXvujbt6/pc00NL9+3b5/GjBmjvXv3KjExUb1799abb76pK664wvSNAYQ/K6uRW1m9fMWKFcrNzVVBQYEyMjKUn5+v7OxslZSU+PZ+/b7CwkLdcMMNGjhwoOLj4zV37lwNGzZMH3/8sTp27Gi+AY2A+AlED6/HK6/Jl0Cz9aMFsROILk6Nn6aS7qeeesqudgAIRw1YSO2H+6LWtbDNggULNGHCBI0fP16SVFBQoNdee01LlizR1KlTa9R/4YUX/D7/6U9/0iuvvKK1a9dqzJgxJhvcOIifQPRgIbXgIXYC0cWp8bPBc7oBOJfLMCwV6dR2M9/fJzUvL6/We1RVVam4uFhZWVm+Y263W1lZWSoqKqpXO48dO6YTJ06oTZs2DX9oAGigcNynGwAigVPjp+nVywFEEe93xew5knbt2uW3V2KgXu4DBw7I4/Goffv2fsfbt2+vbdu21euWU6ZMUUpKil/iDgChYngMGR5zw4TM1gcAJ3Jq/CTpBhDQ93uuzZwjSQkJCX5Jt10eeughLV++XIWFhYqPj7f9fgBwOl6vhTmJETA8EgDs5tT4SdINIKTatm2rmJgYlZWV+R0vKytTcnJynefOnz9fDz30kN5++2317t3bzmYCAAAAljCnG0BghsViQmxsrNLT07V27VrfMa/Xq7Vr1yozMzPgeQ8//LBmz56t1atXq3///uZuCgA2MryGpQIA0c6p8ZOebgCBWdl328I+3bm5uRo7dqz69++vAQMGKD8/XxUVFb7VzMeMGaOOHTv6FmObO3eupk+frmXLliktLU2lpaWSpBYtWqhFixam7w8AweT1SF63uVjo9djUGACIIE6NnyTdAAJqrH26r7/+eu3fv1/Tp09XaWmp+vbtq9WrV/sWV9u5c6fc7v8OzFm0aJGqqqr005/+1O86M2bM0MyZM803AACCyPB4ZbhNbnkTAavvAoDdnBo/SboBBNZIPd2SlJOTo5ycnFq/Kyws9Pu8Y8cOS/cAgMZgeAwZJntqImH1XQCwm1PjJ0k3gIBc3lPF7DkAEM28HsPC8Mjwf2kEALs5NX6ykBoAAAAAADahpxtAYI04vBwAnMKpcxIBwG5OjZ8k3QACs7AFmOn6AOAwXsOQ1+QWNl5+YAkAjo2fJN0AAnIZhlwmA5nZ+gDgOB5DhtmtHCJgTiIA2M6h8ZOkG0BgDC8HANO8Hq+8JleV9EbA8EgAsJtT4ydJN4DADElm4xg5N4AoZ1joqYmELW8AwG5OjZ+sXg4AAAAAgE3o6QYQEHO6AcA8p/bUAIDdnBo/SboBBGbIwpxuW1oCABHDqXMSAcBuTo2fJN0AAmMhNQAwzTAMGSa3vDGInQDg2PjZ6El39S/KSZ2gRyziuELdAFuVHwn/n5KZVX701DNZDkZemf9td94vY1io/j08cuRIiFtiDyf/78DZkVMyPFWhbkLQGZ4Tp/5tMXZ6PYa8Jv9UeyNgeGSkqv59PPFtRYhbYo8qB/+Pt7y8PNRNsJXbgf+DqH5PIX76a/Sku/o3YqNeb+xbo6HC/89zg7Q+N9QtsM+RI0eUmJho+jzmdIeP6tjZ7ZxzQtwSIHpYjZ2Gx5BhMhGKhDmJkao6fv4195oQtwRmLe2QHOomwCLip79GT7pTUlK0a9cutWzZUi6XvT/eKS8vV2pqqnbt2qWEhARb79XYeLbI1NjPZhiGjhw5opSUFNvvBXs1ZuyU+HsYqXi24CB2OgvvnsHBs0Uu4mfoNXrS7Xa71alTp0a9Z0JCgiP/Akk8W6RqzGez8lNGH+Z0h41QxE6Jv4eRimdruIbEzlM9NeG1+u7Bgwd122236W9/+5vcbreuu+46Pfroo2rRokWt9Xfs2KEuXbrU+t3//u//auTIkZJUaxL74osvatSoUcFrfAPx7hlcPFvkIn6GDgupAQiMpBsATAvHOYmjR4/W3r17tWbNGp04cULjx4/XxIkTtWzZslrrp6amau/evX7HFi9erHnz5unKK6/0O7506VINHz7c97lVq1ZBbz+A6BCO8TMYSLoBBEbSDQCmGV6vDJPDmA2vfYthffLJJ1q9erW2bNmi/v37S5Ief/xxXXXVVZo/f36tw0BjYmKUnOw/n3blypX62c9+VqN3vFWrVjXqAoAV4RY/g8Ud6gbYKS4uTjNmzFBcXFyomxJ0PFtkirhn81osiHgR92fVBJ4tMkXSs3k9hqUinZp7+f1SWVnZ4PYUFRWpVatWvoRbkrKysuR2u7Vp06Z6XaO4uFhbt27VzTffXOO7SZMmqW3bthowYICWLFkSEdv32CWS/pyaxbNFrkh6vobEz3DmMqI5MgKoVXl5uRITE5V1bq6axJgL0Cc9lXr70wU6fPiwo+dFAcAPVcfOl9Mu0BnuGFPnVng9+umOD2scnzFjhmbOnNmgds2ZM0fPPPOMSkpK/I4nJSXpgQce0K9//evTXuPWW29VYWGh/v3vf/sdnz17ti6//HI1b95cb731lmbMmKGHH35Yt99+e4PaDCC6BCN+hvO7J8PLAQTG8HIAMM/jlWGYXCX7u+GRP1xduK6eqalTp2ru3Ll1XvaTTz4x145afPvtt1q2bJnuv//+Gt99/1i/fv1UUVGhefPmkXQDsKYB8TOckXQDAACECTOrC0+ePFnjxo2rs07Xrl2VnJysffv2+R0/efKkDh48WK+52C+//LKOHTumMWPGnLZuRkaGZs+ercrKyogYygoAp/Paa69p1qxZ+uCDDxQfH69LL71Uq1atMnUNkm4AgXkNyWWy59pLTzeA6Ob1GPKaHPXjtRA727Vrp3bt2p22XmZmpg4dOqTi4mKlp6dLktatWyev16uMjIzTnv/UU0/pf/7nf+p1r61bt6p169Yk3AAsaaz4WV+vvPKKJkyYoDlz5ujyyy/XyZMn9dFHH5m+Dkk3gMAYXg4Aphkew/RiYoaNL43nnXeehg8frgkTJqigoEAnTpxQTk6ORo0a5Vu5fPfu3Ro6dKieffZZDRgwwHfu9u3btWHDBr3++us1rvu3v/1NZWVl+tGPfqT4+HitWbNGc+bM0W9+8xvbngWAszUkfpaXl/sdj4uLa9APAE+ePKk77rhD8+bN81tEsmfPnqav5ejVywE0lPHfxLu+xeTeigDgNF7DsFTs9MILL6hHjx4aOnSorrrqKg0ePFiLFy/2fX/ixAmVlJTo2LFjfuctWbJEnTp10rBhw2pcs2nTplq4cKEyMzPVt29fPfHEE1qwYIFmzJhh67MAcK6GxM/U1FQlJib6Sl5eXoPa8v7772v37t1yu93q16+fOnTooCuvvJKebgBBRk83AJjmMQx5TMZCs/XNatOmjZYtWxbw+7S0tFp7l+bMmaM5c+bUes7w4cM1fPjwoLURABoSP80sRFkfX3zxhSRp5syZWrBggdLS0vTII49oyJAh+vTTT9WmTZt6X4uebgCBeQ1rBQCimMewVgAg2jUkflYvRFldAiXdU6dOlcvlqrNs27ZN3u9WRf/tb3+r6667Tunp6Vq6dKlcLpdeeuklU89FTzcAAAAAICrUd+eHvXv3SvKfwx0XF6euXbtq586dpu5J0g0gMMN7qpg9BwCiWDgOLweASNAY8bO+Oz+kp6crLi5OJSUlGjx4sKRT61/s2LFDnTt3NnVPkm4AgTGnGwBMszJcnOHlABBe8TMhIUG33HKLZsyYodTUVHXu3Fnz5s2TJI0cOdLUtUi6AQTmtbAaOXO6AUQ5r4WeGrtXLweASBBu8XPevHlq0qSJfv7zn+vbb79VRkaG1q1bp9atW5u6Dkk3gMDo6QYA0zyy0FNjS0sAILKEW/xs2rSp5s+fr/nz5zfoOiTdAAIzZCHptqUlABAxPIYhj8lgyJxuAHBu/GTLMAAAAAAAbEJPN4DAGF4OAKZ5DPPDHVlIDQCcGz9JugEE5vVKMrkFmJctwwBEN6e+NAKA3ZwaP0m6AQRGTzcAmObUOYkAYDenxk+SbgCBkXQDgGleCz017LYIAM6NnyTdAAJjn24AMM2pPTUAYDenxk9WLwcAAAAAwCb0dAMIyDC8MgxzC6OZrQ8ATuPUhYAAwG5OjZ8k3QACMwzzw8UjYIgPANjp1Euj2eGRNjUGACKIU+MnSTeAwAwLc7pJugFEOaf21ACA3ZwaP0m6AQTm9Uouk8PFGV4OIMo5dSEgALCbU+MnSTeAwOjpBgDTDElmf/xI5AQA58ZPkm4AARlerwyTPd0spAYg2jm1pwYA7ObU+MmWYQAAAAAA2ISebgCBMbwcAExz6kJAAGA3p8ZPkm4AgXkNyUXSDQBmOHV4JADYzanxk6QbQGCGheUsIiDwAYCdnNpTAwB2c2r8JOkGEJDhNWSY7Ok2SLoBRDmn9tQAgN2cGj9JugEEZnhlvqeb1csBRDevhZ4ab/i/MwKA7ZwaP1m9HAAAAAAAm9DTDSAghpcDgHlOHR4JAHZzavwk6QYQ0Emj0vRw8ZM6YVNrACAyfCuv6YV9qsxO5QEAB3Jq/CTpBlBDbGyskpOTtbH0dUvnJycnKzY2NsitAoDwVh07Xyjdbel8YieAaOX0+OkyGAsKoBbHjx9XVVWVpXNjY2MVHx8f5BYBQPgjdgKANU6OnyTdAAAAAADYhNXLAQAAAACwCUk3AAAAAAA2IekGAAAAAMAmJN0AAAAAANiEpBsAAAAAAJuQdAMAAAAAYBOSbgAAAAAAbPL/AYJXxPKO128AAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsgAAAD0CAYAAACGjNCJAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8o6BhiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAtnklEQVR4nO3dfbhkZX3m+++9uxsQkSi2EmwaG0d8IRoBe9CEk4iIoeN4wJwYxWgCCQ4zudCjUaMY5xhDxrmIZny5ZpgcexAh0SMadLCTEFER4oiCNIIg4AuiQrcoNi+iog29933+qNVabvauWrVrVdVTte6P17rcVbVW1W/DvqlfPfWsZ8k2ERERERHRMTfpAiIiIiIiSpIGOSIiIiKiSxrkiIiIiIguaZAjIiIiIrqkQY6IiIiI6JIGOSIiIiKiSxrkiIiIiBiYpHMk3SHpyw0930GSPiHpJkk3StrQxPOuRBrkiIiIiFiJc4FNDT7f3wFvt/1k4EjgjgafeyBpkCMiIiJiYLY/A9zVfZ+kfyPp45KulvS/JT2pznNJOhRYbfuT1XP/yPZ9zVddTxrkiIiIiGjKZuCVtp8OvA74HzWPewJwj6SPSrpG0tslrRpZlX2sntQLR0RERMTskLQP8OvAP0jaffee1WP/F3DGEodtt30cnZ70N4DDgVuBDwEnA+8dbdVLS4McETFiko4Gnm/7dRMuJSJWIBmubQ64x/Zhix+w/VHgoz2O3QZca/sWAEkXAs9kQg1yplgURtLRkv5m0nVEREREDML2vcA3Jf0egDqeVvPwq4CHS3pUdfsY4MYRlFlLGuSIiD4k/Uo1J+5eSb824LHvAt4FvFjSZZIeMsCxr5d0t6SLJe09WNURsdskMtyG/Er6IPB54ImStkk6BXgpcIqkLwE3ACfUeS7b83TmLF8i6XpAwP8cTeX9yfakXnumSXoLgO23DHDMu4CjgUcC3wB+2/ZPRvFaEW0n6a+A36EzavFq4PnA7wOPB15m+6quff8rsAH4PdsLi57npcBrgH8DGPgS8FLb27v2OZplvp7td7ykh9IZRXmV7QuH/sUjZoikvYA/pJOfbwCfAG4H9rN9e9d+E8lw8ju9MoI8RpJeWi17ck/1qfIySet2P2771XTeqD9k++jFzXG/4yOiHkn/js5JIL8GPAP4FJ31No8HflL9f7f9gJuWeGM9GfhL4FTgEcAhwPuBu2vW0fd42z8Gvknng3NEVNQ5C+z5wMOAXwb+is6I5YXAoxftPpEMJ7/TKyfpjUkVov8EvBj4Ip2wvIDBQrji4+Pnjnv2Q33nXfO19r36up0X225yEfQow68CZ9n+oaR/BA7avfampHvpNMzdVgMLPNgpwHtsX13d3gGcPUAddY9fIP+9/gVz+x5odv201r7+yZ3J8Qxy5yvwC7rvkzQHfAH43qLdJ5nh5HcJpWc4/8LGZ2Qh7FpKJWrYcdc8V158YK191xzwjbUjLicm4zN0plP8v3RGjB8CIOk3gM/a/tfdO0raD9gI/OsSz/MT4I8lfRv4tO0dA9ZR9/jbgKMlvc/2/QO+xmya38maJ/9OrV3v/+LZyXF7PA14OrBm9x0FZDj5XUrhGc4Ui/HZHaIXSVrJv+hhj4+fMfNeqLXFbLJ9OfAjSb9Z3fUISf8Z+Cfg+dVXt0h6JXAn8APgvCWe6g+Bi4G/Ab4n6R8lLf5qF+AeOvMjV3r8GcCzgR9L2ljz15x5mltVa4tWuQ3YCbwcislw8ruMkjOcBnl8xvVGGn0YWMC1tphdtt9fXSYV4KF0rvb0O8BT6ZzMg+3/BhxAZ37jg87Etv1d26+2fRBwJJ2pG29YYr9rbf/tSo8HXkXnZMJ9bW8d9HedTSr6zTUmoxrB/SDwf1S3S8hw8ruksjOcBnlMxvhGGjUs1PxfzCZJj5G0b3VzNfBN298BLq/u27B7X9vfpbOM0aG9nrOa/nQ9nWZ7YH2OfzLw8Tqr2rSGyn5zjYm6Gbh2940CMpz8LqXwDGcO8gTYvrpa42/FIRzm+LYzZj7LG7bdw4HfpnOFpmcAnwOwvVPS3cDvSsL2pdX+O4E9up9A0unA/wZ2jwi9hM4yjc+pU8CAx6+paoiKAK1K89tmklYBb6MzaPR5Ot+w7kdnDvJLF+0+yQwnv0soPcNpkMdgzG+k0YeBBzI63Gq2b5S0SdIn6Px3+l1dD78P+DZwZdd9Czz4G7d9q30fA/yYzuoyz7F9JfUMcvwqlj4Dv70kVq3eo/9+Mcv2Bc6iM/3wL+nMO74Q+KMlRmsnmeHkdymFZzgN8niM8400asj84rD9DuAdS9z/2iV2/y5wuKQ1th+o9vtz4M+HeP1ax0t6OJ0LEHx3pa81k6qvZ6O9bN9NZ6nTW+hcIKSXiWQ4+e2h8AxnDvIY2P5z20+wvY/t/W3/9iDN7bDHxy8yMG/X2iIqZ9NZCu47kp45rheV9DrgK3SWp7pkXK87DQRobq7WFsEEMpz89lZ6hjOCHK2U77piELZvoTOtadyv+zd05lXGg5Q9+hRlmUSGk99+ys5wGuTRuWxGX2vqGTOfKRYR063wr2cjoo/CM5wGeURsXzaLrzUTDPPpjyOmXslvrhHRX8kZToMcrWPEA+Ty3BHTTBJza8o9Az4ieis9w2mQo3UMLGQEOWK6Ff71bET0UXiG0yBHK81nBDliyom5gt9cI6KfsjNc9Po31UL+X5V0c3WxjGJIOkfSHZK+POlaFpO0XtKlkm6UdIOkV026pm6S9pL0BUlfqur7y3G+vuk0yHW2GF5yvDLJcb8CKPoytbMkGV65knOcDPdWbINcXULyLDqXgz0UeImkntdRH7NzgU2TLmIZu4DX2j4UeCZwWmH/7HYCx9h+GnAYsGmca8sCLFi1thhOcjyU5LgHVUtElfrmOiuS4aGVnONkuIdiG2Q611a/2fYttu8HzgdOmHBNP2P7M8Bdk65jKbZvt/3F6ucfAjcB6yZb1c+540fVzTXVNrZZwRlBHqvkeIWS4/5KfnOdIcnwEErOcTLcW8lzkNcBt3Xd3gY8Y0K1TC1JG4DDgaKuvFeNSlwNPB44a5xXBjTiAedNc0yS4wYkx0u9+Bxzq8s9A36GJMMNKTHHyfDySh5BjiFJ2gf4CPBq2/dOup5utudtHwYcCBwp6Slje20yghzTIzlehkCrVtXaIiat1Bwnw8sruUHeDqzvun1gdV/UIGkNnTB+wPZHJ13PcmzfA1zKWOeQiXnP1dpiaMnxEJLj5ZU+f3GGJMNDmoYcz0KGJT1c0gWSviLpJkm/Nkx9JXcAVwGHSDpY0h7AicCWCdc0FSQJeC9wk+13TLqexSQ9StLDq58fAjwX+Mq4Xt/AAnO1thhacrxCyXHfAtIgj0cyPISSczyDGX438HHbTwKeRme+94oV2wHY3gW8AriYzi/5Yds3TLaqn5P0QeDzwBMlbZN0yqRr6nIU8AfAMZKurbbnTbqoLgcAl0q6js5/fD9p+5/GWUCmWIxHcjyU5LiPNMijlwwPreQcz0yGJf0S8Jt0Poxg+/5qVHzFSj5JD9sXARdNuo6l2H7JpGtYju3PQrndne3r6JyoMKHXV6ZPjFFyvDLJcX9zc83845G0ic7o0yrgbNtnLnr8ncCzq5t7A4+2/fDqsXng+uqxW20f30hRBUmGV67kHE9ZhtdK2tp1e7PtzV23Dwa+D7xP0tPonHj4Kts/XmltRTfIEaNg4AEyqhQxzSQxt2r4D7pd6/w+l84KDVdJ2mL7xt372P7Trv1fyS82FT+pTnKKiAEMmOEdtjf2eHw1cATwSttXSno3cDrw/6y0vgyjRQvlJL2IWTA3p1pbH4Ou8/sS4IMN/QoRrdZQhqHz4XZb1zJ1F9BpmFde2zAHR0yjnKQXMQMEmlOtrY+l1vld8kIOkh5L56vcT3fdvZekrZKukPSCIX6jiHZpLsPY/i5wm6QnVnc9B7ixxyF9ZYpFtNJ8LiMdMdUEtd44K/3mL9Z1InCB7fmu+x5re7ukxwGflnS97W+s4LkjWmXADNfxSuAD1WortwB/NMyTFT9EJunUSdfQS+pbuUnVZsQ8c7W2aEbJf4dQdn0l1waTrE/Mqd5GNX+xa+tujgdZ5/dEFk2vsL29+v9bgMuY8ElPo1Ty32LJtUHqW+ZVB8lwX7avrfL9q7ZfYPvuYaqbhg6g6D8qUt8wJlbbgudqbdGYkv8Ooez6Sq4NJlVfc1/P1lrnV9KTgEfQWVJs932PkLRn9fNaOkt6DfW1buFK/lssuTZIfQ/W4BSLUcgUi2idBcT9zioWEdNMglWrh/8Qa3uXpN3r/K4CzrF9g6QzgK22dzfLJwLn23bX4U8G3iNpgc6A05ndq19ExPKayvCojKRBXrvfKm9Yv6aR5zpo3Wo2Pm0v99+zvq9dt3djz7UXe7Ov9mu0viaVXF/Ttf2UH3O/d9b6qJkT8HrT6r2sPfZp7gnXPJS5vdc29u/68Ccd1NRTAbB+/XqefsQRjdTXdNjWr1/PEQ3VBs0vyNrkPzuAL15zzQ7bj6qzrxqK8VLr/Np+86Lbb1niuM8BT22miuatXbvWBx3UXFaa/ltsUtO1XfuVW5t6qo6G/xv4Kw9r9l/DYx62N0/d/5GNPOn2e3/EXT+p917cVIZHYSQN8ob1a/jCxev77zghx60reIqYi/xvz1S40pfU2s8mS7j1oT32YfUTy73eweWXnzXpEpZVeoJLPz31IXvv/e26+6rm3MS2Ouigg7j88ssnXcayFgoOyyOOOm3SJfT0saN/OukSlnXC/3dx7X1LznCmWEQLiYXi24SI6EWqvT5qRBSo9AynQY7WMRlBjpgFkzp5JyKaUXKG0yBHK2UJt4jpV/Kba0T0V3KG0yBH6xjxQFaxiJhqEqxalQ+6EdOq9AynQY7WMWSN44ipN7n1USOiCWVnOA1ytJCYz0l6EdNNFH2CT0T0UXiGM4wWrbN7BLmpK+lJ2iTpq5JulnT6Eo8fJOlSSddIuk7S85r+nSLaSFKtLSLKVHKGM4IcrdTUCLKkVcBZwHOBbcBVkrYsuprWfwI+bPtvJR1K54IEGxopIKKlRNkXGYiI3krPcBrkaB1bTc5BPhK42fYtAJLOB04AuhtkA/tWP/8S8J2mXjyitQr/ejYi+ig8w2mQo3UMg6xisVbS1q7bm21v7rq9Drit6/Y24BmLnuMtwCckvRJ4KHDsQAVHxBLEXMFnwEdEP2VnOA1ytJAGuVDIDtsbh3zBlwDn2v6vkn4N+HtJT7G9MOTzRrSWCh99iojeSs9wGuRonc5Jeo2Fcjuwvuv2gdV93U4BNgHY/rykvYC1wB1NFRHRRiUvERUR/ZWc4TTI0UoNXknvKuAQSQfTaYxPBH5/0T63As8BzpX0ZGAv4PtNFRDRRhKsKvjNNSJ6Kz3DaZCjdYwaG0G2vUvSK4CLgVXAObZvkHQGsNX2FuC1wP+U9Kd0BrBPtu1GCohosZLfXCOiv5IzXKtBlrQJeDedBuBs22eOtKqIEVtocAlw2xfRWbqt+743d/18I3BUYy+4QslxzBKhot9cRyEZjllSeob7Nsg113mNmBo2PLBQ7pmzo5Acx6yRYI/V7clxMhyzpvQM1xlBrrPOa8TU6EyxKDeUI5Icx0yRYHXBo08jkAzHTBlFhqsPkluB7bafP8xz1WmQ66zzGjFVmrqS3hRJjmOmiLLnL45AMhwzZUQZfhVwEz+/ONeKNTaMJulUSVslbf3+nfNNPW1E43Yv81Zna5PuDHvXTyddTkRv6sxfrLP1fyptkvRVSTdLOn2Jx0+W9H1J11bby7seO0nS16vtpIZ/y4F153jHjh2TLidieQ1muPN0OhD4d8DZTZRXZwS5zjqvVFcX2wyw8Wl75Qz9KFgrp1j0zXF3huf2XpsMR9E6o0/D53iAub0fsv2KRcfuB/wFsJHOZ++rq2PvHrqwBxv4vfiII45IjqNYA2a431VtAd4FvB542PDV1WuQ66zzGjFVFto3xSI5jpnT0Nezw8ztPQ74pO27qmM/SeeiQB9sorBFkuGYOQNkuOdVbSU9H7jD9tWSjm6gtP4N8nLrvDbx4hGT0FnFYtWkyxir5DhmzZw0yBnwvUaf6s7t/V1Jvwl8DfhT27ctc+y6ukUNIhmOWTNghvs5Cjhe0vPoXIxrX0nvt/2ylT5hrXWQl1rnNWJaNXmhkGmSHMesWaVmRp9q+Efgg7Z3SvoPwHnAMUM834okwzFrBshwT7bfCLwRoBpBft0wzTHkSnrRUi2cYhExUxq8TG2d+fl3dt08G3hb17FHLzr2siaKiph1udR0RGF2r2IREdOtoTfXvnN7JR1g+/bq5vF0lpGCznSH/yLpEdXt36IaxYqI/kbRINu+jAY+qKZBjlZq4SoWETOlqYsMLDe3V9IZwFbbW4D/W9LxwC7gLuDk6ti7JP0VnSYb4IzdJ+xFRG+lX+wnDXK0TwvXOI6YNaL++qj9LDW31/abu37+2fzGJY49BzinkUIiWqTJDI9CGuRoHQO7MoIcMdUkmjwDPiLGrPQMp0GO1skc5Ijp18JLTUfMlNIznAY5WikNcsSUK/wM+Ijoo/AMp0GO1mnrOsgRs6T0+YsR0VvpGU6DHK2UdZAjpl/Jb64R0V/JGU6DHO3jTLGImHalX2QgInorPcNpkKN1DOxaKPfM2Yjor/Qz4COit9IznAY5WidzkCOmnxCrlBxHTKvSM5wGOVrJaZAjpt5cwW+uEdFfyRlOgxytlJP0IqabgFWJccTUKj3DI2mQv3bd3hy37vBRPHUjLt5+zaRLWNZxjzls0iXMPOckvb4Of9JBXH75WZMuY1n7/vppky5hWfd+rtx/btCZgz8TBHMFn+BTAgHywqTLWNacyp1/+q3f3XPSJfS04SOTrmB5u35YM5eFZzgjyNFKmWIRMd06o0/JccS0Kj3DaZCjhcR8VrGImGoC1hQ8+hQRvZWe4TTI0TomUywipp5U9NezEdFH4RlOgxzt48485IiYXqLsM+AjorfSM5wGOVopq1hETL+Sz4CPiP5KznAa5Ggdk5P0IqZd6aNPEdFb6RlOgxwtlCvpRUw9waqC5y9GRB+FZzgNcrTSwkK5oYyI/ko/Az4iemsyw5LWA38H7E/ni+LNtt89zHNmratoHbszxaLOFhFlEmJO9ba+zyVtkvRVSTdLOn2Jx18j6UZJ10m6RNJjux6bl3RttW1p+NeMmFlNZhjYBbzW9qHAM4HTJB06TH0ZQY5WyhSLiCnX0NezklYBZwHPBbYBV0naYvvGrt2uATbavk/SnwBvA15cPfYT24cNXUhE2zQ4xcL27cDt1c8/lHQTsA64seeBPWQEOVrJrrdFRJk6J/jU2/o4ErjZ9i227wfOB07o3sH2pbbvq25eARzY8K8T0ToDZnitpK1d26nLPq+0ATgcuHKY+jKCHK2U6RMR02+Ay9SulbS16/Zm25urn9cBt3U9tg14Ro/nOgX4l67be1XPvQs40/aFdYuKaLsBMrzD9sZ+O0naB/gI8Grb9w5TWxrkaB3T7PxiSZuAdwOrgLNtn7nEPi8C3kLn5IEv2f79xgqIaKEBl4iq9eba9zWllwEbgWd13f1Y29slPQ74tKTrbX9j2NeKmHVNL/MmaQ2d5vgDtj867POlQY72cXNzkOvMX5R0CPBG4Cjbd0t6dCMvHtFiEqxp5ioD24H1XbcPrO5b9Ho6FngT8CzbO3ffb3t79f+3SLqMzle7aZAj+mgww0gS8F7gJtvvaOI5Mwc52sk1t/76zl8E/j1wlu27AWzf0cBvENFyYpXqbX1cBRwi6WBJewAnAr+wGoWkw4H3AMd351fSIyTtWf28FjiKIU4KimiXxjIMnez9AXBM16oyzxumuowgRysNMMWi19xFqDd/8QkAki6nMw3jLbY/PljFEdGtqa9nbe+S9ArgYjr5PMf2DZLOALba3gK8HdgH+IfOQBW32j4eeDLwHkkLdAaczly0+kVELKPJKRa2P1s9ZWP6NsiSzgGeD9xh+ylNvnjEpAywQkUTcxdXA4cAR9P5+vYzkp5q+54hn7e25DhmjmBVQ9+B2r4IuGjRfW/u+vnYZY77HPDUZqroLzmOmdJghkehTmnnAptGXEfE2JhGLxRSZ/7iNmCL7QdsfxP4Gp2GeZzOJTmOGbJ79KmhiwxMi3NJjmNGlJ7hvg2y7c8Ad42hlojxMGDV2/rrO38RuJDO6PHueYpPAG5p6tepIzmOWSTV22ZFchyzpuQMNzYHuVq0+VSAvdi7qaeNGAkvNPQ89eYvXgz8lqQbgXngz2zf2UwFzenO8Pr16/vsHTFZYqA1VFsjOY5pUXqGG2uQqxOXNgPsq/1yDbIoWLPrINeYv2jgNdVWrO4MP/2II5LhKF5DV6mdKclxTJOSM5xVLKKd8rYRMd1mbPpEROsUnuE0yNE+zqWmI6adEHPNruoUEWNUeob7nqQn6YPA54EnStom6ZTRlxUxYs1dKGQqJMcxi0o+wWcUkuOYNSVnuO8Isu2XjKOQiPGaoXfNGpLjmEUlz18cheQ4Zk3JGc4Ui2inhlaxiIjJKP0M+IjorfQMp0GO9tm9DnJETLWC31sjooaSM5wGOVppgEtNR0ShCr5KbUTUUHKG0yBHO6VBjphqnZN3Ch5+ioieSs9wGuRop0yxiJh6JZ/gExH9lZzhNMjRSsoIcsTUK3jwKSJqKDnDaZCjfSxYKDiVEdFX6WfAR0RvpWc4DXK0U0aQI6abyv56NiL6KDzDaZCjndIgR0y9gt9bI6KGkjOcBjnaKQ1yxFQTZY8+RURvpWc4DXK0Ty4UEjETSl4iKiL6KznDJa/RHDEycr0tIsq0e/Spztb3uaRNkr4q6WZJpy/x+J6SPlQ9fqWkDV2PvbG6/6uSjmvyd4yYZU1mGPrneFAZQY52SvMbMeXUyBnwklYBZwHPBbYBV0naYvvGrt1OAe62/XhJJwJ/DbxY0qHAicCvAI8BPiXpCbbnhy4sYuY1k2GoneOBjK5BLvhavsc95rBJl7Csi79z7aRL6Om4dYdPuoTlDfAnl9Hh3kzZnyHu/dxZky5hWfv++mmTLqGnkv/ZDUSNraF6JHCz7VsAJJ0PnAB0v7GeALyl+vkC4L+r893wCcD5tncC35R0c/V8n2+ksiHdes0NvPqhvzLpMpa1+oKPTbqEZb39te+YdAk9/eC1k65geUcddW29HZvLMNTL8UAyghztlDnIEVNNNqo/ELNW0tau25ttb65+Xgfc1vXYNuAZi47/2T62d0n6AfDI6v4rFh27rm5REW3WYIahXo4HkgY52qf04dGIqMcLdffcYXvjKEuJiBUoOMNpkKOd0iBHTD3Vf3PtZTuwvuv2gdV9S+2zTdJq4JeAO2seGxHLaCjDMIIsZhWLaKWsYhEx7dwZfaqz9XYVcIikgyXtQeekuy2L9tkCnFT9/ELg07Zd3X9itcrFwcAhwBca+xUjZlpjGYZ6OR5IRpCjnRr70BoRE2HDwvCLRVRzil8BXAysAs6xfYOkM4CttrcA7wX+vjoJ7y46b75U+32YzolAu4DTsoJFRE0NZbjzVEvneJjnTIMcrZPR4YjZ0NTXs7YvAi5adN+bu37+KfB7yxz7VuCtjRQS0TINTrFYMsfDSIMc7ZRVLCKmX4NvrhExAQVnOA1ytFNGkCOmnIt+c42IfsrOcBrkaKVMsYiYcqboN9eI6KPwDKdBjnZKgxwx5QwL5b65RkQ/ZWc4DXK0j0HlZjIiatLCrkmXEBFDKDnDaZCjnTKCHDHd7M4WEdOp8AynQY5WyhzkiBlQ8PzFiKih4AynQY6IiKnU5BqqETF+JWc4DXK0U0aQI6Zc2UtERUQ/ZWc4DXK0T66kFzEbCn5zjYgaCs5wGuRop3IzGRE1yC76DPiI6K30DM/120HSekmXSrpR0g2SXjWOwiJGRXRGkOtssyI5jpm0sFBvmwHJcMykgjPct0EGdgGvtX0o8EzgNEmHjrasiBFzza0GSZskfVXSzZJO77Hf70qypI1DVr8SyXHMGP98mah+22xIhmPGlJ3hvg2y7dttf7H6+YfATcC6URcWMTI1R4/rjCBLWgWcBfw2cCjwkqXetCQ9DHgVcGWzv0w9yXHMnN2Xqa2zzYBkOGZO4RmuM4L8M5I2AIezxJu8pFMlbZW09QF2NlRexIg0N4J8JHCz7Vts3w+cD5ywxH5/Bfw18NNhSx/WcjnuzvCOHTsmUlvEIOSFWtusqfte/FPmx15bxCBKznDtBlnSPsBHgFfbvnfx47Y3295oe+Ma9myyxojm1W+Q1+5+s6m2Uxc90zrgtq7b21g0qiPpCGC97X8ewW8ykF457s7w2rVrJ1NgRG0uevRpVAZ5L96LVeMvMKK2sjNcaxULSWvoBPIDtj862pIiRk/187bD9ornDEuaA94BnLzS52hKchwzxYb5ByZdxVglwzFTCs9w3wZZkoD3AjfZfsfoS4oYsQFOwKthO7C+6/aB1X27PQx4CnBZJ0r8MrBF0vG2tzZWRR/Jccwiz8gKFXUkwzGLSs5wnSkWRwF/ABwj6dpqe96I64oYqQaXebsKOETSwZL2AE4Etux+0PYPbK+1vcH2BuAKYKzNcSU5jhljWJivt82GZDhmTNkZ7juCbPuzdJaOjZgdDY0g294l6RXAxcAq4BzbN0g6A9hqe0vvZxiP5DhmjhnLG6ek/YAPARuAbwEvsn33on0OA/4W2BeYB95q+0PVY+cCzwJ+UO1+su1rB60jGY6ZM6YMr1SupBet1ORFQGxfBFy06L43L7Pv0c29ckR7GeP5sby5ng5cYvvMap3z04E3LNrnPuAPbX9d0mOAqyVdbPue6vE/s33BOIqNmBbjyrCktwP/J3A/8A3gj7qyuayBlnmLmBkNXigkIibAjOsqXCcA51U/nwe84EGl2F+z/fXq5+8AdwCPGvaFI2ba+DL8SeAptn8V+BrwxjoHZQQ5WmfWLiMd0UpewLvur7v3Wknd8/43295c89j9bd9e/fxdYP9eO0s6EtiDzkjVbm+V9GbgEuB027lYQMRgGV75y9if6Lp5BfDCOselQY52SoMcMf3qjyz1XK5R0qforDCz2Ju6b9i2tPzHa0kHAH8PnGT/bPHWN9JprPcANtOZnnFG3cIjZlr9DA/zIbfbH9M5p6CvNMjRShlBjph2xg2d4GP72OUek/Q9SQfYvr1qgO9YZr99gX8G3mT7iq7n3j36vFPS+4DXNVJ0xNQbKMMr/pBr+2PVPm8CdgEfqPOCaZCjndIgR0y38Z0BvwU4CTiz+v+PLd6hWuLxfwF/t/hkvK7mWnTmL3955BVHTIMGM9zrQy6ApJOB5wPPsV2rA0iDHO2UBjliyrmJk3fqOBP4sKRTgG8DLwKQtBH4j7ZfXt33m8Ajqzdi+Plybh+Q9Cg6S7RdC/zHcRQdUb7xZFjSJuD1wLNs31f3uDTI0T45SS9i+pmxLBFl+07gOUvcvxV4efXz+4H3L3P8MSMtMGJajSnDwH8H9gQ+WV3R9grbfT+opkGOVlK5V7eMiDq8AGM4Az4iRmRMGbb9+JUclwY52ikjyBFTz+OZYhERI1JyhtMgRytlikXEtHPRl6mNiH7KznAa5GifXCUvYvqNbxWLiBiFwjOcBjnaKQ1yxFQzLvrr2YjorfQMp0EuzHHrDp90CT1dvP2aSZewrCOPq7d6i8gUi35UbaUq+V/fvZ87a9Il9LTvr5826RKaUfjoUwnmH/s47vqL8yZdxrL2e+EJky5hWbrvpkmX0FPJ/w2srfAMp0GOVtLCTPznJaK9bPxAVrGImFqFZzgNcrRP5iBHzICxXSgkIkai7AynQY5WyhSLiBlQ8NezEVFDwRlOgxztlAY5YrrZuOA314joo/AMp0GOVsoIcsT0K/kM+Ijor+QMp0GOdkqDHDHdbDxf7ptrRPRReIbTIEf7GFRuJiOiBtssPLBr0mVExAqVnuE0yNE6WQc5YgaYokefIqKPwjOcBjnayemQI6ZdyW+uEdFfyRlOgxytlBHkiOlmm4X5cs+Aj4jeSs9wGuRon1woJGImlHwGfET0V3KG0yBHK+UkvYgpV/gZ8BHRR+EZToMcrZQGOWK6lX4GfET0VnqG0yBH+5icpBcxAxbGMPokaT/gQ8AG4FvAi2zfvcR+88D11c1bbR9f3X8wcD7wSOBq4A9s3z/ywiOmwDgyvFJzky4gYhLkeltEFKpaIqrONqTTgUtsHwJcUt1eyk9sH1Ztx3fd/9fAO20/HrgbOGXYgiJmwvgyvCJpkKOdXHOLiDJV8xfH8OZ6AnBe9fN5wAvqHihJwDHABSs5PmKmjS/DAEh6rSRLWltn/75TLCTtBXwG2LPa/wLbfzFcmRGT08YLhSTHMWvMQGfAr5W0tev2Ztubax67v+3bq5+/C+y/zH57Va+xCzjT9oV0plXcY3v3RMttwLq6RXdLhmPWDJjhoUhaD/wWcGvdY+rMQd4JHGP7R5LWAJ+V9C+2r1hhnRGTZbdxDnJyHLNlsDPgd9jeuNyDkj4F/PISD73pF1/Slpb9eP1Y29slPQ74tKTrgR/ULbCGZDhmy3hXsXgn8HrgY3UP6Nsg2zbwo+rmmmprXXcRs6Vtq1gkxzFzDPMNnQFv+9jlHpP0PUkH2L5d0gHAHcs8x/bq/2+RdBlwOPAR4OGSVlejyAcC21dYYzIcs2WwDK/4WyBJJwDbbX+pM+upnlqrWEhaRefs28cDZ9m+svYrRBSobVMsIDmO2WLGNvq0BTgJOLP6/weNQEl6BHCf7Z3V/MajgLdVI86XAi+ks5LFksfXlQzHLBkww8N8C/TndKZXDKTWSXq2520fRufT75GSnrJEcadK2ipp6wPsHLSOiPExsOB62wzpl+PuDH9/x46J1BhRm8Hz87W2IZ0JPFfS14Fjq9tI2ijp7GqfJwNbJX0JuJTOHOQbq8feALxG0s105iS/d6WFDPpevPNH96z0pSJGr8EM2z7W9lMWb8AtwMHAlyR9i052vihpqWb6Fwy0DrLte6pPw5uALy96bDOwGWBf7TdbnUXMnhb/hS6X4+4MP/2II1r8Tyimg8dygo/tO4HnLHH/VuDl1c+fA566zPG3AEc2XFOt9+L9Njw5OY6CjT7Dtq8HHr37dtUkb7TddxSo7wiypEdJenj180OA5wJfWWmxESVoch1kSZskfVXSzZIetEaqpNdIulHSdZIukfTYpn+fGjUmxzFbCl9DtWnJcMycwjNcZwT5AOC8au7THPBh2/802rIiRqyhVSyqXJxF581qG3CVpC1dX68CXEPnE+t9kv4EeBvw4kYKqC85jhkz1jPgS5AMx4wZf4Ztb6i7b51VLK6jczZuxGxwo6tYHAncXH2NiqTz6VxY4GcNsu1Lu/a/AnhZY69eU3Ics8Z2Y6tYTINkOGZN6RkeaA5yxCzoXCik9ghyv6Vl1gG3dd3eBjyjx/OdAvxL3RePiGVUX89GxJQqPMNpkKOd6mey59Iyg5D0MmAj8Kwmni+i1QyezzloEVOr8AynQY5WGmAEuZ/twPqu20teCEDSsXTWY3yW7ayDGDEkYxYKHn2KiN5Kz3Aa5Ggf0+Qyb1cBh0g6mE5jfCLw+907SDoceA+wyfaSV+GKiAEZPGNrlUe0SuEZToMcLeTGVrGwvUvSK4CLgVXAObZvkHQGsNX2FuDtwD7AP1SXubzV9vGNFBDRYgsFfz0bEf2VnOE0yNFKavBTq+2LgIsW3ffmrp+PbezFIgLojDwt3D/0VfIiYkJKz3Aa5GifZpd5i4gJKXn0KSL6KznDaZCjnZo7SS8iJqHwJaIioo/CM5wGOdop/XHEVDOwUPAJPhHRW+kZToMcrdTgMm8RMQl20WuoRkQfhWc4DXK0UxrkiKlX8hqqEdFfyRlOgxytIxsV/Kk1IvrzAizcX+6ba0T0VnqG0yBHO2UEOWLKlX0Vrojop+wMp0GOdkqDHDHdCr8KV0T0UXiGR9Ig/5C7d3zKF3y7oadbC+xo6LlGodn6mv9babS+VQc09UxA8/9uH1trLwPlfmgtwhevuWbHQ/beu6kMQ9ty3KySa4MJ5diUvYZqCe7+9ld2/MMfP6MtOW60tvfsvXdTT7Vbyf/soNn6ZiLDI2mQbT+qqeeStNX2xqaer2mpb+UmWVtWseityQxD2X+HUHZ9JdcGE6zPHssaqpL2Az4EbAC+BbzI9t2L9nk28M6uu54EnGj7QknnAs8CflA9drLta0dbdUebclxybZD6ljSmDK/U3KQLiJgIu94WEcXyvGttQzoduMT2IcAl1e1frMO+1PZhtg8DjgHuAz7Rtcuf7X58XM1xxDQYU4ZXJHOQo31sWCj3U2tE9GfD/APz43ipE4Cjq5/PAy4D3tBj/xcC/2L7vtGWFTHdxpjhFZmGEeTNky6gj9S3cpOrbaHmFk0p+e8Qyq6v5NpgUvXZLMzX24a0v+3bq5+/C+zfZ/8TgQ8uuu+tkq6T9E5Jew5b0ASV/LdYcm2Q+h5sfBlekeJHkG0X/UeV+lZukrVlDvJ4lfx3CGXXV3JtMMH6zCBfva6VtLXr9ubuuiV9CvjlJY570y+8pG1Jy76opAOApwIXd939RjqN9R50mpA3AGfULbwkJf8tllwbpL6lX3SgDA9F0iuB04B54J9tv77fMcU3yBEjkQY5YqoZBjnBZ0evE5BsH7vcY5K+J+kA27dXDfAdPV7nRcD/sv1A13PvHn3eKel9wOvqFh0xywbM8IpVJ9GeADzN9k5Jj65z3DRMsYholoEF19siokxmXF/PbgFOqn4+CfhYj31fwqLpFVVTjSQBLwC+PGxBETNhfBn+E+BM2zsBbPf6kPszaZCjhWquYJFR5oiC1Tv7vYGvcM8Enivp68Cx1W0kbZR09u6dJG0A1gP/uuj4D0i6Hriezlqz/3nYgiJmw0AZXitpa9d26gAv9ATgNyRdKelfJf3bOgdlikW0U1axiJhqNjwwhhzbvhN4zhL3bwVe3nX7W8C6JfY7ZpT1RUyrATPcc5pUn/MIVgP7Ac8E/i3wYUmPs3uPgqVBjvbZPcUiIqaWgYIvwhURfTSZ4T7nEfwJ8NGqIf6CpAU63+Z8v9dzpkGOFjI4I8gR024+06AiptqYMnwh8GzgUklPoLOiTN/LaqdBjnbKG2vEVMsIcsR0G2OGzwHOkfRl4H7gpH7TKyANcrRRplhETD07I8gR02xcGbZ9P/CyQY9LgxztlDfWiKmXEeSI6VZyhtMgRws5q1hETLkFzP35JihiapWe4TTI0T4mDXLEDCh59Cki+is5w2mQo50yxSJiqmUOcsR0Kz3DaZCjnQoOZUTUU/LoU0T0V3KG0yBHCzmrWERMuc4SUclxxLQqPcNpkKN9DM6FQiKmWtZBjphupWc4DXK003wa5IhpZlP0GfAR0VvpGU6DHO3jLPMWMQtK/no2IvorOcNpkKOdCg5lRPRnIB9zI6ZX6RlOgxyt5IwgR0w5Fz36FBH9lJ3hNMjRQs4IcsSUK/0En4jorfQMp0GO9jFZ5i1iypW+RFRE9FZ6htMgR+sY8Pz8pMuIiCGUfgZ8RPRWeobTIEf72JB1kCOmXslfz0ZEfyVnOA1ytJIL/tQaEf2V/vVsRPRWeobTIEc7ZQQ5YqqVfoJPRPRWeoblgrv3iFGQ9HFgbc3dd9jeNMp6ImJwyXHEdCs9w2mQIyIiIiK6zE26gIiIiIiIkqRBjoiIiIjokgY5IiIiIqJLGuSIiIiIiC5pkCMiIiIiuvz/5vXfEfrKwMkAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<Figure size 1000x350 with 6 Axes>"
+       "<Figure size 720x252 with 6 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -1660,8 +1618,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:24:36]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=38186;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=864901;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0mdata/fdve-\u001b[93m35cd21ba-c710-4a4b-82be-42b161393984\u001b[0mv1.hdf5   \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:24:36]\u001B[0m\u001B[2;36m \u001B[0mloading SimulationData from                             \u001B]8;id=38186;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=864901;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001B\\\u001B[2m590\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0mdata/fdve-\u001B[93m35cd21ba-c710-4a4b-82be-42b161393984\u001B[0mv1.hdf5   \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -1676,9 +1634,9 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: \u001b[0m\u001b[32m'int'\u001b[0m\u001b[31m field name is deprecated and will be  \u001b[0m \u001b]8;id=388332;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py\u001b\\\u001b[2msim_data.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=465787;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py#497\u001b\\\u001b[2m497\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[31mremoved in the future. Plese use \u001b[0m\u001b[33mfield_name\u001b[0m\u001b[31m=\u001b[0m\u001b[32m'E'\u001b[0m\u001b[31m and  \u001b[0m \u001b[2m               \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b[33mval\u001b[0m\u001b[31m=\u001b[0m\u001b[32m'abs^2'\u001b[0m\u001b[31m for the same effect.                     \u001b[0m \u001b[2m               \u001b[0m\n"
+       "\u001B[2;36m          \u001B[0m\u001B[2;36m \u001B[0m\u001B[31mWARNING: \u001B[0m\u001B[32m'int'\u001B[0m\u001B[31m field name is deprecated and will be  \u001B[0m \u001B]8;id=388332;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py\u001B\\\u001B[2msim_data.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=465787;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py#497\u001B\\\u001B[2m497\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B[31mremoved in the future. Plese use \u001B[0m\u001B[33mfield_name\u001B[0m\u001B[31m=\u001B[0m\u001B[32m'E'\u001B[0m\u001B[31m and  \u001B[0m \u001B[2m               \u001B[0m\n",
+       "\u001B[2;36m           \u001B[0m\u001B[33mval\u001B[0m\u001B[31m=\u001B[0m\u001B[32m'abs^2'\u001B[0m\u001B[31m for the same effect.                     \u001B[0m \u001B[2m               \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -1692,8 +1650,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:24:38]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=48658;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=994475;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0mdata/fdve-\u001b[93mfb655fca-e9c2-4ae9-819d-6a15f80d1132\u001b[0mv1.hdf5   \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:24:38]\u001B[0m\u001B[2;36m \u001B[0mloading SimulationData from                             \u001B]8;id=48658;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=994475;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001B\\\u001B[2m590\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0mdata/fdve-\u001B[93mfb655fca-e9c2-4ae9-819d-6a15f80d1132\u001B[0mv1.hdf5   \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -1708,9 +1666,9 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: \u001b[0m\u001b[32m'int'\u001b[0m\u001b[31m field name is deprecated and will be  \u001b[0m \u001b]8;id=517097;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py\u001b\\\u001b[2msim_data.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=984589;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py#497\u001b\\\u001b[2m497\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[31mremoved in the future. Plese use \u001b[0m\u001b[33mfield_name\u001b[0m\u001b[31m=\u001b[0m\u001b[32m'E'\u001b[0m\u001b[31m and  \u001b[0m \u001b[2m               \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b[33mval\u001b[0m\u001b[31m=\u001b[0m\u001b[32m'abs^2'\u001b[0m\u001b[31m for the same effect.                     \u001b[0m \u001b[2m               \u001b[0m\n"
+       "\u001B[2;36m          \u001B[0m\u001B[2;36m \u001B[0m\u001B[31mWARNING: \u001B[0m\u001B[32m'int'\u001B[0m\u001B[31m field name is deprecated and will be  \u001B[0m \u001B]8;id=517097;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py\u001B\\\u001B[2msim_data.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=984589;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py#497\u001B\\\u001B[2m497\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B[31mremoved in the future. Plese use \u001B[0m\u001B[33mfield_name\u001B[0m\u001B[31m=\u001B[0m\u001B[32m'E'\u001B[0m\u001B[31m and  \u001B[0m \u001B[2m               \u001B[0m\n",
+       "\u001B[2;36m           \u001B[0m\u001B[33mval\u001B[0m\u001B[31m=\u001B[0m\u001B[32m'abs^2'\u001B[0m\u001B[31m for the same effect.                     \u001B[0m \u001B[2m               \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -1730,10 +1688,10 @@
    "source": [
     "f, (ax1, ax2) = plt.subplots(2, 1, tight_layout=True, figsize=(15, 10))\n",
     "ax1 = modeler.batch.load(path_dir=\"data\")[\"smatrix_left_top_0\"].plot_field(\n",
-    "    \"field\", \"int\", z=wg_height / 2, ax=ax1\n",
+    "    \"field\", field_name=\"E\", val=\"abs^2\", z=wg_height / 2, ax=ax1\n",
     ")\n",
     "ax2 = modeler.batch.load(path_dir=\"data\")[\"smatrix_right_bot_0\"].plot_field(\n",
-    "    \"field\", \"int\", z=wg_height / 2, ax=ax2\n",
+    "    \"field\", field_name=\"E\", val=\"abs^2\", z=wg_height / 2, ax=ax2\n",
     ")\n"
    ]
   },
@@ -1767,8 +1725,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:24:41]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=246800;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=997293;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0mdata/fdve-\u001b[93m35cd21ba-c710-4a4b-82be-42b161393984\u001b[0mv1.hdf5   \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:24:41]\u001B[0m\u001B[2;36m \u001B[0mloading SimulationData from                             \u001B]8;id=246800;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=997293;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001B\\\u001B[2m590\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0mdata/fdve-\u001B[93m35cd21ba-c710-4a4b-82be-42b161393984\u001B[0mv1.hdf5   \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -1783,9 +1741,9 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: \u001b[0m\u001b[32m'int'\u001b[0m\u001b[31m field name is deprecated and will be  \u001b[0m \u001b]8;id=398873;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py\u001b\\\u001b[2msim_data.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=697561;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py#497\u001b\\\u001b[2m497\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[31mremoved in the future. Plese use \u001b[0m\u001b[33mfield_name\u001b[0m\u001b[31m=\u001b[0m\u001b[32m'E'\u001b[0m\u001b[31m and  \u001b[0m \u001b[2m               \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b[33mval\u001b[0m\u001b[31m=\u001b[0m\u001b[32m'abs^2'\u001b[0m\u001b[31m for the same effect.                     \u001b[0m \u001b[2m               \u001b[0m\n"
+       "\u001B[2;36m          \u001B[0m\u001B[2;36m \u001B[0m\u001B[31mWARNING: \u001B[0m\u001B[32m'int'\u001B[0m\u001B[31m field name is deprecated and will be  \u001B[0m \u001B]8;id=398873;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py\u001B\\\u001B[2msim_data.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=697561;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py#497\u001B\\\u001B[2m497\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B[31mremoved in the future. Plese use \u001B[0m\u001B[33mfield_name\u001B[0m\u001B[31m=\u001B[0m\u001B[32m'E'\u001B[0m\u001B[31m and  \u001B[0m \u001B[2m               \u001B[0m\n",
+       "\u001B[2;36m           \u001B[0m\u001B[33mval\u001B[0m\u001B[31m=\u001B[0m\u001B[32m'abs^2'\u001B[0m\u001B[31m for the same effect.                     \u001B[0m \u001B[2m               \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -1799,8 +1757,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:24:43]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=731028;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=179311;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0mdata/fdve-\u001b[93mfb655fca-e9c2-4ae9-819d-6a15f80d1132\u001b[0mv1.hdf5   \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:24:43]\u001B[0m\u001B[2;36m \u001B[0mloading SimulationData from                             \u001B]8;id=731028;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=179311;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001B\\\u001B[2m590\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0mdata/fdve-\u001B[93mfb655fca-e9c2-4ae9-819d-6a15f80d1132\u001B[0mv1.hdf5   \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -1815,9 +1773,9 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: \u001b[0m\u001b[32m'int'\u001b[0m\u001b[31m field name is deprecated and will be  \u001b[0m \u001b]8;id=410484;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py\u001b\\\u001b[2msim_data.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=368210;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py#497\u001b\\\u001b[2m497\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[31mremoved in the future. Plese use \u001b[0m\u001b[33mfield_name\u001b[0m\u001b[31m=\u001b[0m\u001b[32m'E'\u001b[0m\u001b[31m and  \u001b[0m \u001b[2m               \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b[33mval\u001b[0m\u001b[31m=\u001b[0m\u001b[32m'abs^2'\u001b[0m\u001b[31m for the same effect.                     \u001b[0m \u001b[2m               \u001b[0m\n"
+       "\u001B[2;36m          \u001B[0m\u001B[2;36m \u001B[0m\u001B[31mWARNING: \u001B[0m\u001B[32m'int'\u001B[0m\u001B[31m field name is deprecated and will be  \u001B[0m \u001B]8;id=410484;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py\u001B\\\u001B[2msim_data.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=368210;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/components/data/sim_data.py#497\u001B\\\u001B[2m497\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B[31mremoved in the future. Plese use \u001B[0m\u001B[33mfield_name\u001B[0m\u001B[31m=\u001B[0m\u001B[32m'E'\u001B[0m\u001B[31m and  \u001B[0m \u001B[2m               \u001B[0m\n",
+       "\u001B[2;36m           \u001B[0m\u001B[33mval\u001B[0m\u001B[31m=\u001B[0m\u001B[32m'abs^2'\u001B[0m\u001B[31m for the same effect.                     \u001B[0m \u001B[2m               \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -1919,8 +1877,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:24:45]\u001b[0m\u001b[2;36m \u001b[0mCreated task \u001b[32m'smatrix_right_top_0'\u001b[0m with task_id         \u001b]8;id=717615;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=373048;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001b\\\u001b[2m188\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1'\u001b[0m.          \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:24:45]\u001B[0m\u001B[2;36m \u001B[0mCreated task \u001B[32m'smatrix_right_top_0'\u001B[0m with task_id         \u001B]8;id=717615;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=373048;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001B\\\u001B[2m188\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B[32m'fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1'\u001B[0m.          \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -1935,9 +1893,9 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mView task using web UI at                               \u001b]8;id=770145;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=742108;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001b\\\u001b[2m190\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=816404;https://tidy3d.simulation.cloud/workbench?taskId=fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1\u001b\\\u001b[32m'https://tidy3d.simulation.cloud/workbench?\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=90673;https://tidy3d.simulation.cloud/workbench?taskId=fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1\u001b\\\u001b[32mtaskId\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=816404;https://tidy3d.simulation.cloud/workbench?taskId=fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1\u001b\\\u001b[32m=\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=483858;https://tidy3d.simulation.cloud/workbench?taskId=fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1\u001b\\\u001b[32mfdve\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=816404;https://tidy3d.simulation.cloud/workbench?taskId=fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1\u001b\\\u001b[32m-\u001b[0m\u001b]8;;\u001b\\ \u001b[2m             \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=816404;https://tidy3d.simulation.cloud/workbench?taskId=fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1\u001b\\\u001b[32m4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1'\u001b[0m\u001b]8;;\u001b\\.                \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m          \u001B[0m\u001B[2;36m \u001B[0mView task using web UI at                               \u001B]8;id=770145;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=742108;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001B\\\u001B[2m190\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B]8;id=816404;https://tidy3d.simulation.cloud/workbench?taskId=fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1\u001B\\\u001B[32m'https://tidy3d.simulation.cloud/workbench?\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=90673;https://tidy3d.simulation.cloud/workbench?taskId=fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1\u001B\\\u001B[32mtaskId\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=816404;https://tidy3d.simulation.cloud/workbench?taskId=fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1\u001B\\\u001B[32m=\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=483858;https://tidy3d.simulation.cloud/workbench?taskId=fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1\u001B\\\u001B[32mfdve\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=816404;https://tidy3d.simulation.cloud/workbench?taskId=fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1\u001B\\\u001B[32m-\u001B[0m\u001B]8;;\u001B\\ \u001B[2m             \u001B[0m\n",
+       "\u001B[2;36m           \u001B[0m\u001B]8;id=816404;https://tidy3d.simulation.cloud/workbench?taskId=fdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1\u001B\\\u001B[32m4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1'\u001B[0m\u001B]8;;\u001B\\.                \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -1988,8 +1946,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:24:46]\u001b[0m\u001b[2;36m \u001b[0mCreated task \u001b[32m'smatrix_right_bot_0'\u001b[0m with task_id         \u001b]8;id=360866;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=177422;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001b\\\u001b[2m188\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1'\u001b[0m.          \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:24:46]\u001B[0m\u001B[2;36m \u001B[0mCreated task \u001B[32m'smatrix_right_bot_0'\u001B[0m with task_id         \u001B]8;id=360866;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=177422;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001B\\\u001B[2m188\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B[32m'fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1'\u001B[0m.          \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2004,9 +1962,9 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mView task using web UI at                               \u001b]8;id=567876;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=81100;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001b\\\u001b[2m190\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=462624;https://tidy3d.simulation.cloud/workbench?taskId=fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1\u001b\\\u001b[32m'https://tidy3d.simulation.cloud/workbench?\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=400492;https://tidy3d.simulation.cloud/workbench?taskId=fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1\u001b\\\u001b[32mtaskId\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=462624;https://tidy3d.simulation.cloud/workbench?taskId=fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1\u001b\\\u001b[32m=\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=419919;https://tidy3d.simulation.cloud/workbench?taskId=fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1\u001b\\\u001b[32mfdve\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=462624;https://tidy3d.simulation.cloud/workbench?taskId=fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1\u001b\\\u001b[32m-\u001b[0m\u001b]8;;\u001b\\ \u001b[2m             \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=462624;https://tidy3d.simulation.cloud/workbench?taskId=fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1\u001b\\\u001b[32m6609948e-9edb-4cfd-9132-8c0de1e12b27v1'\u001b[0m\u001b]8;;\u001b\\.                \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m          \u001B[0m\u001B[2;36m \u001B[0mView task using web UI at                               \u001B]8;id=567876;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=81100;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001B\\\u001B[2m190\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B]8;id=462624;https://tidy3d.simulation.cloud/workbench?taskId=fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1\u001B\\\u001B[32m'https://tidy3d.simulation.cloud/workbench?\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=400492;https://tidy3d.simulation.cloud/workbench?taskId=fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1\u001B\\\u001B[32mtaskId\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=462624;https://tidy3d.simulation.cloud/workbench?taskId=fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1\u001B\\\u001B[32m=\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=419919;https://tidy3d.simulation.cloud/workbench?taskId=fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1\u001B\\\u001B[32mfdve\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=462624;https://tidy3d.simulation.cloud/workbench?taskId=fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1\u001B\\\u001B[32m-\u001B[0m\u001B]8;;\u001B\\ \u001B[2m             \u001B[0m\n",
+       "\u001B[2;36m           \u001B[0m\u001B]8;id=462624;https://tidy3d.simulation.cloud/workbench?taskId=fdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1\u001B\\\u001B[32m6609948e-9edb-4cfd-9132-8c0de1e12b27v1'\u001B[0m\u001B]8;;\u001B\\.                \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2057,8 +2015,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mCreated task \u001b[32m'smatrix_left_top_0'\u001b[0m with task_id          \u001b]8;id=99932;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=793748;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001b\\\u001b[2m188\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1'\u001b[0m.          \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m          \u001B[0m\u001B[2;36m \u001B[0mCreated task \u001B[32m'smatrix_left_top_0'\u001B[0m with task_id          \u001B]8;id=99932;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=793748;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001B\\\u001B[2m188\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B[32m'fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1'\u001B[0m.          \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2073,9 +2031,9 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mView task using web UI at                               \u001b]8;id=396306;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=670730;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001b\\\u001b[2m190\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=710549;https://tidy3d.simulation.cloud/workbench?taskId=fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1\u001b\\\u001b[32m'https://tidy3d.simulation.cloud/workbench?\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=352042;https://tidy3d.simulation.cloud/workbench?taskId=fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1\u001b\\\u001b[32mtaskId\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=710549;https://tidy3d.simulation.cloud/workbench?taskId=fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1\u001b\\\u001b[32m=\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=247893;https://tidy3d.simulation.cloud/workbench?taskId=fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1\u001b\\\u001b[32mfdve\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=710549;https://tidy3d.simulation.cloud/workbench?taskId=fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1\u001b\\\u001b[32m-\u001b[0m\u001b]8;;\u001b\\ \u001b[2m             \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=710549;https://tidy3d.simulation.cloud/workbench?taskId=fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1\u001b\\\u001b[32m458d2239-0779-4d48-92b1-f7c0d021609ev1'\u001b[0m\u001b]8;;\u001b\\.                \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m          \u001B[0m\u001B[2;36m \u001B[0mView task using web UI at                               \u001B]8;id=396306;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=670730;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001B\\\u001B[2m190\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B]8;id=710549;https://tidy3d.simulation.cloud/workbench?taskId=fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1\u001B\\\u001B[32m'https://tidy3d.simulation.cloud/workbench?\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=352042;https://tidy3d.simulation.cloud/workbench?taskId=fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1\u001B\\\u001B[32mtaskId\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=710549;https://tidy3d.simulation.cloud/workbench?taskId=fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1\u001B\\\u001B[32m=\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=247893;https://tidy3d.simulation.cloud/workbench?taskId=fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1\u001B\\\u001B[32mfdve\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=710549;https://tidy3d.simulation.cloud/workbench?taskId=fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1\u001B\\\u001B[32m-\u001B[0m\u001B]8;;\u001B\\ \u001B[2m             \u001B[0m\n",
+       "\u001B[2;36m           \u001B[0m\u001B]8;id=710549;https://tidy3d.simulation.cloud/workbench?taskId=fdve-458d2239-0779-4d48-92b1-f7c0d021609ev1\u001B\\\u001B[32m458d2239-0779-4d48-92b1-f7c0d021609ev1'\u001B[0m\u001B]8;;\u001B\\.                \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2126,8 +2084,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:24:47]\u001b[0m\u001b[2;36m \u001b[0mCreated task \u001b[32m'smatrix_left_bot_0'\u001b[0m with task_id          \u001b]8;id=603725;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=405732;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001b\\\u001b[2m188\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1'\u001b[0m.          \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:24:47]\u001B[0m\u001B[2;36m \u001B[0mCreated task \u001B[32m'smatrix_left_bot_0'\u001B[0m with task_id          \u001B]8;id=603725;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=405732;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001B\\\u001B[2m188\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B[32m'fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1'\u001B[0m.          \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2142,9 +2100,9 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mView task using web UI at                               \u001b]8;id=314674;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=922543;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001b\\\u001b[2m190\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=777057;https://tidy3d.simulation.cloud/workbench?taskId=fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1\u001b\\\u001b[32m'https://tidy3d.simulation.cloud/workbench?\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=134650;https://tidy3d.simulation.cloud/workbench?taskId=fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1\u001b\\\u001b[32mtaskId\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=777057;https://tidy3d.simulation.cloud/workbench?taskId=fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1\u001b\\\u001b[32m=\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=6556;https://tidy3d.simulation.cloud/workbench?taskId=fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1\u001b\\\u001b[32mfdve\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=777057;https://tidy3d.simulation.cloud/workbench?taskId=fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1\u001b\\\u001b[32m-\u001b[0m\u001b]8;;\u001b\\ \u001b[2m             \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=777057;https://tidy3d.simulation.cloud/workbench?taskId=fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1\u001b\\\u001b[32mccc9701f-20f7-4937-a40b-bff4b9e7e42bv1'\u001b[0m\u001b]8;;\u001b\\.                \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m          \u001B[0m\u001B[2;36m \u001B[0mView task using web UI at                               \u001B]8;id=314674;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=922543;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001B\\\u001B[2m190\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B]8;id=777057;https://tidy3d.simulation.cloud/workbench?taskId=fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1\u001B\\\u001B[32m'https://tidy3d.simulation.cloud/workbench?\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=134650;https://tidy3d.simulation.cloud/workbench?taskId=fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1\u001B\\\u001B[32mtaskId\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=777057;https://tidy3d.simulation.cloud/workbench?taskId=fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1\u001B\\\u001B[32m=\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=6556;https://tidy3d.simulation.cloud/workbench?taskId=fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1\u001B\\\u001B[32mfdve\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=777057;https://tidy3d.simulation.cloud/workbench?taskId=fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1\u001B\\\u001B[32m-\u001B[0m\u001B]8;;\u001B\\ \u001B[2m             \u001B[0m\n",
+       "\u001B[2;36m           \u001B[0m\u001B]8;id=777057;https://tidy3d.simulation.cloud/workbench?taskId=fdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1\u001B\\\u001B[32mccc9701f-20f7-4937-a40b-bff4b9e7e42bv1'\u001B[0m\u001B]8;;\u001B\\.                \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2194,7 +2152,7 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:24:48]\u001b[0m\u001b[2;36m \u001b[0mStarted working on Batch.                            \u001b]8;id=263637;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001b\\\u001b[2mcontainer.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=385381;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#475\u001b\\\u001b[2m475\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001B[2;36m[16:24:48]\u001B[0m\u001B[2;36m \u001B[0mStarted working on Batch.                            \u001B]8;id=263637;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001B\\\u001B[2mcontainer.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=385381;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#475\u001B\\\u001B[2m475\u001B[0m\u001B]8;;\u001B\\\n"
       ]
      },
      "metadata": {},
@@ -2209,9 +2167,9 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:25:12]\u001b[0m\u001b[2;36m \u001b[0mMaximum FlexCredit cost: \u001b[1;36m1.763\u001b[0m for the whole batch.  \u001b]8;id=174349;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001b\\\u001b[2mcontainer.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=986673;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#479\u001b\\\u001b[2m479\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0mUse \u001b[32m'Batch.real_cost\u001b[0m\u001b[32m(\u001b[0m\u001b[32m)\u001b[0m\u001b[32m'\u001b[0m to get the billed FlexCredit \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0mcost after the Batch has completed.                  \u001b[2m                \u001b[0m\n"
+       "\u001B[2;36m[16:25:12]\u001B[0m\u001B[2;36m \u001B[0mMaximum FlexCredit cost: \u001B[1;36m1.763\u001B[0m for the whole batch.  \u001B]8;id=174349;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001B\\\u001B[2mcontainer.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=986673;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#479\u001B\\\u001B[2m479\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0mUse \u001B[32m'Batch.real_cost\u001B[0m\u001B[32m(\u001B[0m\u001B[32m)\u001B[0m\u001B[32m'\u001B[0m to get the billed FlexCredit \u001B[2m                \u001B[0m\n",
+       "\u001B[2;36m           \u001B[0mcost after the Batch has completed.                  \u001B[2m                \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2238,7 +2196,7 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:28:11]\u001b[0m\u001b[2;36m \u001b[0mBatch complete.                                      \u001b]8;id=860697;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001b\\\u001b[2mcontainer.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=299807;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#522\u001b\\\u001b[2m522\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001B[2;36m[16:28:11]\u001B[0m\u001B[2;36m \u001B[0mBatch complete.                                      \u001B]8;id=860697;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001B\\\u001B[2mcontainer.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=299807;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#522\u001B\\\u001B[2m522\u001B[0m\u001B]8;;\u001B\\\n"
       ]
      },
      "metadata": {},
@@ -2312,8 +2270,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:28:18]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=248880;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=251160;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m.\u001b[35m/\u001b[0m\u001b[95mfdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1.hdf5\u001b[0m      \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:28:18]\u001B[0m\u001B[2;36m \u001B[0mloading SimulationData from                             \u001B]8;id=248880;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=251160;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001B\\\u001B[2m590\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m.\u001B[35m/\u001B[0m\u001B[95mfdve-4ae19a0b-6656-4767-b012-1dc3e17e3dfdv1.hdf5\u001B[0m      \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2364,8 +2322,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:28:24]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=782619;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=998930;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m.\u001b[35m/\u001b[0m\u001b[95mfdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1.hdf5\u001b[0m      \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:28:24]\u001B[0m\u001B[2;36m \u001B[0mloading SimulationData from                             \u001B]8;id=782619;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=998930;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001B\\\u001B[2m590\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m.\u001B[35m/\u001B[0m\u001B[95mfdve-6609948e-9edb-4cfd-9132-8c0de1e12b27v1.hdf5\u001B[0m      \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2416,8 +2374,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:28:30]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=271337;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=484755;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m.\u001b[35m/\u001b[0m\u001b[95mfdve-458d2239-0779-4d48-92b1-f7c0d021609ev1.hdf5\u001b[0m      \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:28:30]\u001B[0m\u001B[2;36m \u001B[0mloading SimulationData from                             \u001B]8;id=271337;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=484755;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001B\\\u001B[2m590\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m.\u001B[35m/\u001B[0m\u001B[95mfdve-458d2239-0779-4d48-92b1-f7c0d021609ev1.hdf5\u001B[0m      \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2468,8 +2426,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:28:36]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=803965;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=757363;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m.\u001b[35m/\u001b[0m\u001b[95mfdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1.hdf5\u001b[0m      \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:28:36]\u001B[0m\u001B[2;36m \u001B[0mloading SimulationData from                             \u001B]8;id=803965;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=757363;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001B\\\u001B[2m590\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m.\u001B[35m/\u001B[0m\u001B[95mfdve-ccc9701f-20f7-4937-a40b-bff4b9e7e42bv1.hdf5\u001B[0m      \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2484,6 +2442,7 @@
     "    freqs=[freq0],\n",
     "    element_mappings=element_mappings,\n",
     "    verbose=True,\n",
+    "    path_dir=\"data\"\n",
     ")\n",
     "smatrix = modeler.run()\n"
    ]
@@ -2560,8 +2519,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:28:40]\u001b[0m\u001b[2;36m \u001b[0mCreated task \u001b[32m'smatrix_left_top_0'\u001b[0m with task_id          \u001b]8;id=498668;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=93889;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001b\\\u001b[2m188\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1'\u001b[0m.          \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:28:40]\u001B[0m\u001B[2;36m \u001B[0mCreated task \u001B[32m'smatrix_left_top_0'\u001B[0m with task_id          \u001B]8;id=498668;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=93889;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001B\\\u001B[2m188\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B[32m'fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1'\u001B[0m.          \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2576,9 +2535,9 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mView task using web UI at                               \u001b]8;id=677780;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=674938;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001b\\\u001b[2m190\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=895873;https://tidy3d.simulation.cloud/workbench?taskId=fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1\u001b\\\u001b[32m'https://tidy3d.simulation.cloud/workbench?\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=219532;https://tidy3d.simulation.cloud/workbench?taskId=fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1\u001b\\\u001b[32mtaskId\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=895873;https://tidy3d.simulation.cloud/workbench?taskId=fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1\u001b\\\u001b[32m=\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=712813;https://tidy3d.simulation.cloud/workbench?taskId=fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1\u001b\\\u001b[32mfdve\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=895873;https://tidy3d.simulation.cloud/workbench?taskId=fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1\u001b\\\u001b[32m-\u001b[0m\u001b]8;;\u001b\\ \u001b[2m             \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=895873;https://tidy3d.simulation.cloud/workbench?taskId=fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1\u001b\\\u001b[32mf39c4ead-9fac-421b-abbf-60900dcbde93v1'\u001b[0m\u001b]8;;\u001b\\.                \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m          \u001B[0m\u001B[2;36m \u001B[0mView task using web UI at                               \u001B]8;id=677780;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=674938;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001B\\\u001B[2m190\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B]8;id=895873;https://tidy3d.simulation.cloud/workbench?taskId=fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1\u001B\\\u001B[32m'https://tidy3d.simulation.cloud/workbench?\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=219532;https://tidy3d.simulation.cloud/workbench?taskId=fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1\u001B\\\u001B[32mtaskId\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=895873;https://tidy3d.simulation.cloud/workbench?taskId=fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1\u001B\\\u001B[32m=\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=712813;https://tidy3d.simulation.cloud/workbench?taskId=fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1\u001B\\\u001B[32mfdve\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=895873;https://tidy3d.simulation.cloud/workbench?taskId=fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1\u001B\\\u001B[32m-\u001B[0m\u001B]8;;\u001B\\ \u001B[2m             \u001B[0m\n",
+       "\u001B[2;36m           \u001B[0m\u001B]8;id=895873;https://tidy3d.simulation.cloud/workbench?taskId=fdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1\u001B\\\u001B[32mf39c4ead-9fac-421b-abbf-60900dcbde93v1'\u001B[0m\u001B]8;;\u001B\\.                \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2629,8 +2588,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mCreated task \u001b[32m'smatrix_left_bot_0'\u001b[0m with task_id          \u001b]8;id=797428;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=284095;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001b\\\u001b[2m188\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b[32m'fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1'\u001b[0m.          \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m          \u001B[0m\u001B[2;36m \u001B[0mCreated task \u001B[32m'smatrix_left_bot_0'\u001B[0m with task_id          \u001B]8;id=797428;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=284095;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#188\u001B\\\u001B[2m188\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B[32m'fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1'\u001B[0m.          \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2645,9 +2604,9 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mView task using web UI at                               \u001b]8;id=13205;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=97499;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001b\\\u001b[2m190\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=412500;https://tidy3d.simulation.cloud/workbench?taskId=fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1\u001b\\\u001b[32m'https://tidy3d.simulation.cloud/workbench?\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=353209;https://tidy3d.simulation.cloud/workbench?taskId=fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1\u001b\\\u001b[32mtaskId\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=412500;https://tidy3d.simulation.cloud/workbench?taskId=fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1\u001b\\\u001b[32m=\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=836542;https://tidy3d.simulation.cloud/workbench?taskId=fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1\u001b\\\u001b[32mfdve\u001b[0m\u001b]8;;\u001b\\\u001b]8;id=412500;https://tidy3d.simulation.cloud/workbench?taskId=fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1\u001b\\\u001b[32m-\u001b[0m\u001b]8;;\u001b\\ \u001b[2m             \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0m\u001b]8;id=412500;https://tidy3d.simulation.cloud/workbench?taskId=fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1\u001b\\\u001b[32m5dfff954-b1b1-4089-92a3-bb2e14376305v1'\u001b[0m\u001b]8;;\u001b\\.                \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m          \u001B[0m\u001B[2;36m \u001B[0mView task using web UI at                               \u001B]8;id=13205;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=97499;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#190\u001B\\\u001B[2m190\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m\u001B]8;id=412500;https://tidy3d.simulation.cloud/workbench?taskId=fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1\u001B\\\u001B[32m'https://tidy3d.simulation.cloud/workbench?\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=353209;https://tidy3d.simulation.cloud/workbench?taskId=fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1\u001B\\\u001B[32mtaskId\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=412500;https://tidy3d.simulation.cloud/workbench?taskId=fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1\u001B\\\u001B[32m=\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=836542;https://tidy3d.simulation.cloud/workbench?taskId=fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1\u001B\\\u001B[32mfdve\u001B[0m\u001B]8;;\u001B\\\u001B]8;id=412500;https://tidy3d.simulation.cloud/workbench?taskId=fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1\u001B\\\u001B[32m-\u001B[0m\u001B]8;;\u001B\\ \u001B[2m             \u001B[0m\n",
+       "\u001B[2;36m           \u001B[0m\u001B]8;id=412500;https://tidy3d.simulation.cloud/workbench?taskId=fdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1\u001B\\\u001B[32m5dfff954-b1b1-4089-92a3-bb2e14376305v1'\u001B[0m\u001B]8;;\u001B\\.                \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2697,7 +2656,7 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:28:42]\u001b[0m\u001b[2;36m \u001b[0mStarted working on Batch.                            \u001b]8;id=149874;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001b\\\u001b[2mcontainer.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=413163;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#475\u001b\\\u001b[2m475\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001B[2;36m[16:28:42]\u001B[0m\u001B[2;36m \u001B[0mStarted working on Batch.                            \u001B]8;id=149874;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001B\\\u001B[2mcontainer.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=413163;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#475\u001B\\\u001B[2m475\u001B[0m\u001B]8;;\u001B\\\n"
       ]
      },
      "metadata": {},
@@ -2712,9 +2671,9 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:28:51]\u001b[0m\u001b[2;36m \u001b[0mMaximum FlexCredit cost: \u001b[1;36m0.881\u001b[0m for the whole batch.  \u001b]8;id=780440;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001b\\\u001b[2mcontainer.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=476839;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#479\u001b\\\u001b[2m479\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0mUse \u001b[32m'Batch.real_cost\u001b[0m\u001b[32m(\u001b[0m\u001b[32m)\u001b[0m\u001b[32m'\u001b[0m to get the billed FlexCredit \u001b[2m                \u001b[0m\n",
-       "\u001b[2;36m           \u001b[0mcost after the Batch has completed.                  \u001b[2m                \u001b[0m\n"
+       "\u001B[2;36m[16:28:51]\u001B[0m\u001B[2;36m \u001B[0mMaximum FlexCredit cost: \u001B[1;36m0.881\u001B[0m for the whole batch.  \u001B]8;id=780440;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001B\\\u001B[2mcontainer.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=476839;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#479\u001B\\\u001B[2m479\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0mUse \u001B[32m'Batch.real_cost\u001B[0m\u001B[32m(\u001B[0m\u001B[32m)\u001B[0m\u001B[32m'\u001B[0m to get the billed FlexCredit \u001B[2m                \u001B[0m\n",
+       "\u001B[2;36m           \u001B[0mcost after the Batch has completed.                  \u001B[2m                \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2741,7 +2700,7 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:30:16]\u001b[0m\u001b[2;36m \u001b[0mBatch complete.                                      \u001b]8;id=745877;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001b\\\u001b[2mcontainer.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=274239;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#522\u001b\\\u001b[2m522\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001B[2;36m[16:30:16]\u001B[0m\u001B[2;36m \u001B[0mBatch complete.                                      \u001B]8;id=745877;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py\u001B\\\u001B[2mcontainer.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=274239;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/container.py#522\u001B\\\u001B[2m522\u001B[0m\u001B]8;;\u001B\\\n"
       ]
      },
      "metadata": {},
@@ -2815,8 +2774,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:30:24]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=283697;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=471712;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m.\u001b[35m/\u001b[0m\u001b[95mfdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1.hdf5\u001b[0m      \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:30:24]\u001B[0m\u001B[2;36m \u001B[0mloading SimulationData from                             \u001B]8;id=283697;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=471712;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001B\\\u001B[2m590\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m.\u001B[35m/\u001B[0m\u001B[95mfdve-f39c4ead-9fac-421b-abbf-60900dcbde93v1.hdf5\u001B[0m      \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2867,8 +2826,8 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[16:30:29]\u001b[0m\u001b[2;36m \u001b[0mloading SimulationData from                             \u001b]8;id=10692;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001b\\\u001b[2mwebapi.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=58708;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001b\\\u001b[2m590\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m           \u001b[0m.\u001b[35m/\u001b[0m\u001b[95mfdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1.hdf5\u001b[0m      \u001b[2m             \u001b[0m\n"
+       "\u001B[2;36m[16:30:29]\u001B[0m\u001B[2;36m \u001B[0mloading SimulationData from                             \u001B]8;id=10692;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py\u001B\\\u001B[2mwebapi.py\u001B[0m\u001B]8;;\u001B\\\u001B[2m:\u001B[0m\u001B]8;id=58708;file:///home/momchil/Drive/flexcompute/tidy3d-docs/tidy3d/tidy3d/web/webapi.py#590\u001B\\\u001B[2m590\u001B[0m\u001B]8;;\u001B\\\n",
+       "\u001B[2;36m           \u001B[0m.\u001B[35m/\u001B[0m\u001B[95mfdve-5dfff954-b1b1-4089-92a3-bb2e14376305v1.hdf5\u001B[0m      \u001B[2m             \u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -2878,7 +2837,7 @@
    "source": [
     "run_only = (left_top, left_bot)\n",
     "modeler = ComponentModeler(\n",
-    "    simulation=sim, ports=ports, freqs=[freq0], run_only=run_only, verbose=True\n",
+    "    simulation=sim, ports=ports, freqs=[freq0], run_only=run_only, verbose=True, path_dir=\"data\"\n",
     ")\n",
     "smatrix = modeler.run()\n"
    ]
@@ -2948,7 +2907,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.12"
   },
   "title": "Scattering Matrix Computation in Tidy3D | Flexcompute",
   "widgets": {
@@ -2973,7 +2932,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">↑</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">simulation.hdf5.gz</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">3.2/3.2 kB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">?</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;31m↑\u001b[0m \u001b[1;34msimulation.hdf5.gz\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m3.2/3.2 kB\u001b[0m • \u001b[31m?\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;31m↑\u001B[0m \u001B[1;34msimulation.hdf5.gz\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m3.2/3.2 kB\u001B[0m • \u001B[31m?\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3002,7 +2961,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">↓</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">monitor_data.hdf5</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">22.9/22.9 MB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">4.5 MB/s</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;32m↓\u001b[0m \u001b[1;34mmonitor_data.hdf5\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m22.9/22.9 MB\u001b[0m • \u001b[31m4.5 MB/s\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;32m↓\u001B[0m \u001B[1;34mmonitor_data.hdf5\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m22.9/22.9 MB\u001B[0m • \u001B[31m4.5 MB/s\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3084,7 +3043,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">↓</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">monitor_data.hdf5</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">22.9/22.9 MB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">4.4 MB/s</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;32m↓\u001b[0m \u001b[1;34mmonitor_data.hdf5\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m22.9/22.9 MB\u001b[0m • \u001b[31m4.4 MB/s\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;32m↓\u001B[0m \u001B[1;34mmonitor_data.hdf5\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m22.9/22.9 MB\u001B[0m • \u001B[31m4.4 MB/s\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3272,7 +3231,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">↓</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">monitor_data.hdf5</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">22.9/22.9 MB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">5.5 MB/s</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;32m↓\u001b[0m \u001b[1;34mmonitor_data.hdf5\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m22.9/22.9 MB\u001b[0m • \u001b[31m5.5 MB/s\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;32m↓\u001B[0m \u001B[1;34mmonitor_data.hdf5\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m22.9/22.9 MB\u001B[0m • \u001B[31m5.5 MB/s\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3354,7 +3313,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">↓</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">monitor_data.hdf5</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">22.9/22.9 MB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">5.4 MB/s</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;32m↓\u001b[0m \u001b[1;34mmonitor_data.hdf5\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m22.9/22.9 MB\u001b[0m • \u001b[31m5.4 MB/s\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;32m↓\u001B[0m \u001B[1;34mmonitor_data.hdf5\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m22.9/22.9 MB\u001B[0m • \u001B[31m5.4 MB/s\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3383,7 +3342,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">smatrix_right_top_0: status = success <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\nsmatrix_right_bot_0: status = success <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\nsmatrix_left_top_0: status = success  <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\nsmatrix_left_bot_0: status = success  <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "smatrix_right_top_0: status = success \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[36m0:00:00\u001b[0m\nsmatrix_right_bot_0: status = success \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[36m0:00:00\u001b[0m\nsmatrix_left_top_0: status = success  \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[36m0:00:00\u001b[0m\nsmatrix_left_bot_0: status = success  \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "smatrix_right_top_0: status = success \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[36m0:00:00\u001B[0m\nsmatrix_right_bot_0: status = success \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[36m0:00:00\u001B[0m\nsmatrix_left_top_0: status = success  \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[36m0:00:00\u001B[0m\nsmatrix_left_bot_0: status = success  \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3465,7 +3424,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">smatrix_left_top_0: status = success <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\nsmatrix_left_bot_0: status = success <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "smatrix_left_top_0: status = success \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[36m0:00:00\u001b[0m\nsmatrix_left_bot_0: status = success \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "smatrix_left_top_0: status = success \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[36m0:00:00\u001B[0m\nsmatrix_left_bot_0: status = success \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3653,7 +3612,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">↑</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">simulation.hdf5.gz</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">3.2/3.2 kB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">?</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;31m↑\u001b[0m \u001b[1;34msimulation.hdf5.gz\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m3.2/3.2 kB\u001b[0m • \u001b[31m?\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;31m↑\u001B[0m \u001B[1;34msimulation.hdf5.gz\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m3.2/3.2 kB\u001B[0m • \u001B[31m?\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3735,7 +3694,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">↑</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">simulation.hdf5.gz</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">3.2/3.2 kB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">?</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;31m↑\u001b[0m \u001b[1;34msimulation.hdf5.gz\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m3.2/3.2 kB\u001b[0m • \u001b[31m?\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;31m↑\u001B[0m \u001B[1;34msimulation.hdf5.gz\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m3.2/3.2 kB\u001B[0m • \u001B[31m?\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3764,7 +3723,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">↓</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">monitor_data.hdf5</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">22.9/22.9 MB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">6.5 MB/s</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;32m↓\u001b[0m \u001b[1;34mmonitor_data.hdf5\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m22.9/22.9 MB\u001b[0m • \u001b[31m6.5 MB/s\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;32m↓\u001B[0m \u001B[1;34mmonitor_data.hdf5\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m22.9/22.9 MB\u001B[0m • \u001B[31m6.5 MB/s\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3793,7 +3752,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">↑</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">simulation.hdf5.gz</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">3.2/3.2 kB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">?</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;31m↑\u001b[0m \u001b[1;34msimulation.hdf5.gz\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m3.2/3.2 kB\u001b[0m • \u001b[31m?\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;31m↑\u001B[0m \u001B[1;34msimulation.hdf5.gz\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m3.2/3.2 kB\u001B[0m • \u001B[31m?\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3822,7 +3781,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">smatrix_right_top_0: status = success <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\nsmatrix_right_bot_0: status = success <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\nsmatrix_left_top_0: status = success  <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\nsmatrix_left_bot_0: status = success  <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "smatrix_right_top_0: status = success \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[36m0:00:00\u001b[0m\nsmatrix_right_bot_0: status = success \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[36m0:00:00\u001b[0m\nsmatrix_left_top_0: status = success  \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[36m0:00:00\u001b[0m\nsmatrix_left_bot_0: status = success  \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "smatrix_right_top_0: status = success \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[36m0:00:00\u001B[0m\nsmatrix_right_bot_0: status = success \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[36m0:00:00\u001B[0m\nsmatrix_left_top_0: status = success  \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[36m0:00:00\u001B[0m\nsmatrix_left_bot_0: status = success  \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3957,7 +3916,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">↓</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">monitor_data.hdf5</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">22.9/22.9 MB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">4.9 MB/s</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;32m↓\u001b[0m \u001b[1;34mmonitor_data.hdf5\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m22.9/22.9 MB\u001b[0m • \u001b[31m4.9 MB/s\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;32m↓\u001B[0m \u001B[1;34mmonitor_data.hdf5\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m22.9/22.9 MB\u001B[0m • \u001B[31m4.9 MB/s\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3986,7 +3945,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">↓</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">monitor_data.hdf5</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">22.9/22.9 MB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">3.9 MB/s</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;32m↓\u001b[0m \u001b[1;34mmonitor_data.hdf5\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m22.9/22.9 MB\u001b[0m • \u001b[31m3.9 MB/s\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;32m↓\u001B[0m \u001B[1;34mmonitor_data.hdf5\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m22.9/22.9 MB\u001B[0m • \u001B[31m3.9 MB/s\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -4121,7 +4080,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">↑</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">simulation.hdf5.gz</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">3.2/3.2 kB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">?</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;31m↑\u001b[0m \u001b[1;34msimulation.hdf5.gz\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m3.2/3.2 kB\u001b[0m • \u001b[31m?\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;31m↑\u001B[0m \u001B[1;34msimulation.hdf5.gz\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m3.2/3.2 kB\u001B[0m • \u001B[31m?\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -4150,7 +4109,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">↑</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">simulation.hdf5.gz</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">3.2/3.2 kB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">?</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;31m↑\u001b[0m \u001b[1;34msimulation.hdf5.gz\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m3.2/3.2 kB\u001b[0m • \u001b[31m?\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;31m↑\u001B[0m \u001B[1;34msimulation.hdf5.gz\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m3.2/3.2 kB\u001B[0m • \u001B[31m?\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -4391,7 +4350,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">↑</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">simulation.hdf5.gz</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">3.2/3.2 kB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">?</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;31m↑\u001b[0m \u001b[1;34msimulation.hdf5.gz\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m3.2/3.2 kB\u001b[0m • \u001b[31m?\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;31m↑\u001B[0m \u001B[1;34msimulation.hdf5.gz\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m3.2/3.2 kB\u001B[0m • \u001B[31m?\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -4420,7 +4379,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">↑</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">simulation.hdf5.gz</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">3.2/3.2 kB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">?</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;31m↑\u001b[0m \u001b[1;34msimulation.hdf5.gz\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m3.2/3.2 kB\u001b[0m • \u001b[31m?\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;31m↑\u001B[0m \u001B[1;34msimulation.hdf5.gz\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m3.2/3.2 kB\u001B[0m • \u001B[31m?\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -4449,7 +4408,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">↑</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">simulation.hdf5.gz</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">3.2/3.2 kB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">?</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;31m↑\u001b[0m \u001b[1;34msimulation.hdf5.gz\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m3.2/3.2 kB\u001b[0m • \u001b[31m?\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;31m↑\u001B[0m \u001B[1;34msimulation.hdf5.gz\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m3.2/3.2 kB\u001B[0m • \u001B[31m?\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -4478,7 +4437,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">↑</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">simulation.hdf5.gz</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">3.2/3.2 kB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">?</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;31m↑\u001b[0m \u001b[1;34msimulation.hdf5.gz\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m3.2/3.2 kB\u001b[0m • \u001b[31m?\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;31m↑\u001B[0m \u001B[1;34msimulation.hdf5.gz\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m3.2/3.2 kB\u001B[0m • \u001B[31m?\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -4507,7 +4466,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">↓</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">monitor_data.hdf5</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">22.9/22.9 MB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">3.8 MB/s</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;32m↓\u001b[0m \u001b[1;34mmonitor_data.hdf5\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m22.9/22.9 MB\u001b[0m • \u001b[31m3.8 MB/s\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;32m↓\u001B[0m \u001B[1;34mmonitor_data.hdf5\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m22.9/22.9 MB\u001B[0m • \u001B[31m3.8 MB/s\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -4695,7 +4654,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">↓</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">monitor_data.hdf5</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">22.9/22.9 MB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">3.5 MB/s</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;32m↓\u001b[0m \u001b[1;34mmonitor_data.hdf5\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m22.9/22.9 MB\u001b[0m • \u001b[31m3.5 MB/s\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;32m↓\u001B[0m \u001B[1;34mmonitor_data.hdf5\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m22.9/22.9 MB\u001B[0m • \u001B[31m3.5 MB/s\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -4830,7 +4789,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">↓</span> <span style=\"color: #000080; text-decoration-color: #000080; font-weight: bold\">monitor_data.hdf5</span> <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100.0%</span> • <span style=\"color: #008000; text-decoration-color: #008000\">22.9/22.9 MB</span> • <span style=\"color: #800000; text-decoration-color: #800000\">6.1 MB/s</span> • <span style=\"color: #008080; text-decoration-color: #008080\">0:00:00</span>\n</pre>\n",
-          "text/plain": "\u001b[1;32m↓\u001b[0m \u001b[1;34mmonitor_data.hdf5\u001b[0m \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100.0%\u001b[0m • \u001b[32m22.9/22.9 MB\u001b[0m • \u001b[31m6.1 MB/s\u001b[0m • \u001b[36m0:00:00\u001b[0m\n"
+          "text/plain": "\u001B[1;32m↓\u001B[0m \u001B[1;34mmonitor_data.hdf5\u001B[0m \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100.0%\u001B[0m • \u001B[32m22.9/22.9 MB\u001B[0m • \u001B[31m6.1 MB/s\u001B[0m • \u001B[36m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"


### PR DESCRIPTION
I've just taken the notebook from tidy3d-docs and updated the api links, so that the state gets updated when we run them all? In any case I've run it out of this commit to verify.

From my check this was the only commit in tidy3d-docs not in tidy3d-notebooks I think
https://github.com/flexcompute-readthedocs/tidy3d-docs/commit/d08acb3c79be49eec3131db5e1828eafb8c8c2d7