### PR TITLE
Updated metadata for the prefab adjoint example

### DIFF
--- a/AdjointPlugin14PreFab.ipynb
+++ b/AdjointPlugin14PreFab.ipynb
@@ -2446,14 +2446,14 @@
   }
  ],
  "metadata": {
-  "description": "This notebook demonstrates the inverse design of a compact 3D grating coupler with permittivity binarization and minimum feature size control.",
+  "description": "This notebook demonstrates the inverse design of a compact 3D grating coupler with machine learning-based fabrication constraints.",
   "feature_image": "",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
-  "keywords": "inverse design, grating coupler, photonic integrated circuits, design optimization, adjoint, Tidy3D, FDTD",
+  "keywords": "inverse design, grating coupler, photonic integrated circuits, machine learning, design optimization, adjoint, Tidy3D, FDTD",
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -2464,7 +2464,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.10.12"
   },
   "nbdime-conflicts": {
    "local_diff": [
@@ -2528,7 +2528,7 @@
     }
    ]
   },
-  "title": "Inverse Design of a Grating Coupler in Tidy3D | Flexcompute",
+  "title": "Machine learning-based fabrication constraints for inverse design using PreFab | Flexcompute",
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {


### PR DESCRIPTION
Shuang from MC notified me that the prefab notebook has the same metadata as the grating coupler adjoint notebook. For better SEO, this PR includes some adjustment of the prefab notebook metadata.