### PR TITLE
FIX: temporarily comment out 2.6.1 feature in design plugin notebook

### DIFF
--- a/Design.ipynb
+++ b/Design.ipynb
@@ -10482,7 +10482,9 @@
    "id": "57b72b7d-c14d-44a8-ada4-a7e23ab44940",
    "metadata": {},
    "source": [
-    "### Accessing the batch data\n",
+    "### Accessing the batch data (in >= 2.6.1)\n",
+    "\n",
+    "> Note: this feature will be available in the 2.6.1 patch. In 2.6.0, it will not be possible to do this. For now we leave the code commented out.\n",
     "\n",
     "Finally, if `Design.run_batch()` was used, then the `Result` object also stores the `BatchData` associated with the design run.\n",
     "\n",
@@ -10496,13 +10498,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "batch_data = results.batch_data\n",
-    "batch_data = batch_data.updated_copy(verbose=False)\n",
+    "# batch_data = results.batch_data\n",
+    "# batch_data = batch_data.updated_copy(verbose=False)\n",
     "\n",
-    "flux_dict = {}\n",
-    "for task_name, sim_data in batch_data.items():\n",
-    "    flux = np.sum(sim_data['flux'].flux.values)\n",
-    "    flux_dict[task_name] = flux"
+    "# flux_dict = {}\n",
+    "# for task_name, sim_data in batch_data.items():\n",
+    "#     flux = np.sum(sim_data['flux'].flux.values)\n",
+    "#     flux_dict[task_name] = flux"
    ]
   },
   {
@@ -10559,8 +10561,8 @@
     }
    ],
    "source": [
-    "from pprint import pprint\n",
-    "pprint(flux_dict)"
+    "# from pprint import pprint\n",
+    "# pprint(flux_dict)"
    ]
   }
  ],


### PR DESCRIPTION
jumped the gun and merged #63 without realizing that the front end needs to be released in 2.6.1. This still teases the feature, but comments out the code so the notebook doesn't error.