### PR TITLE
small typo fix prefab notebook

### DIFF
--- a/AdjointPlugin14PreFab.ipynb
+++ b/AdjointPlugin14PreFab.ipynb
@@ -63,7 +63,7 @@
     "- **Prediction**: The process of predicting the structural variations in the design due to the fabrication process.\n",
     "- **Correction**: The process of correcting the design to compensate for the predicted structural variations.\n",
     "- **Outcome**: The prediction of the corrected design.\n",
-    "- **(Un)Constrained**: We analyze the prefab corrections on previously optimized grating couplers. Whether a design is \"constrained\" or \"unconstrained\" refers to whether we applied feature size penalties to the optimization model or not, respectively. \n",
+    "- **(Un)Constrained**: We analyze the prefab corrections on previously optimized grating couplers. Whether a design is \"constrained\" or \"unconstrained\" refers to whether or not we applied feature size penalties (constraints) to the optimization model. \n",
     "\n",
     "Below is an example of a simple target design, its predicted structure after fabrication, the corrected design, and the predicted structure after fabrication of the correction (outcome). With PreFab, the Intersect over Union (IoU) between the predicted and the nominal design starts at `IoU = 0.65`. After applying corrections, the IoU between the outcome and the nominal design rises to `IoU = 0.97`.\n",
     "\n",
@@ -2464,7 +2464,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   },
   "nbdime-conflicts": {
    "local_diff": [


### PR DESCRIPTION
used `respectively` in a way that was actually the opposite meaning when referring to constrained vs unconstrained optimization. fixed. not super urgent