### PR TITLE
fixes import error in adjoint 3

### DIFF
--- a/AdjointPlugin3InverseDesign.ipynb
+++ b/AdjointPlugin3InverseDesign.ipynb
@@ -707,7 +707,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m tidy3d.plugins.adjoint.utils.penalty import ErosionDilationPenalty\n",
+    "from tidy3d.plugins.adjoint.utils.penalty import ErosionDilationPenalty\n",
     "\n",
     "def penalty(params, beta):\n",
     "    processed_params = filter_project(params, beta=beta)\n",
@@ -2336,7 +2336,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.11.7"
   },
   "nbdime-conflicts": {
    "local_diff": [


### PR DESCRIPTION
we should deploy this whenever possible, adjoint notebook 3 will error because I messed up one of the imports.