### PR TITLE
remove mention of asyncio in webapi notebook

### DIFF
--- a/WebAPI.ipynb
+++ b/WebAPI.ipynb
@@ -1559,9 +1559,9 @@
    "id": "b1e19538-d559-4ea2-b555-0df0135417ff",
    "metadata": {},
    "source": [
-    "## Asynchronous Batching\n",
+    "## Simulation Batching\n",
     "\n",
-    "Finally, one can make use of the [asyncio package](https://realpython.com/async-io-python/) to perform asynchronous processing of several simulations.\n",
+    "Finally, one perform batch processing of several simulations in a single function call.\n",
     "\n",
     "For this purpose, a [web.run_async](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.web.api.asynchronous.run_async.html) function is provided, which works like the regular `web.run` but accepts a dictionary of simulations. \n",
     "\n",
@@ -2117,7 +2117,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   },
   "title": "Running Simulations Through the Cloud | Flexcompute",
   "widgets": {


### PR DESCRIPTION
a user was confused since we had some text saying we use `asyncio` in `run_async` when we don't anymore.