### PR TITLE
Minor updates to adjoint notebook removing `to_simulation()` calls where possible

### DIFF
--- a/AdjointPlugin8WaveguideBend.ipynb
+++ b/AdjointPlugin8WaveguideBend.ipynb
@@ -40468,7 +40468,7 @@
     "    sim_data_i = data_history[i]\n",
     "\n",
     "    # plot permittivity\n",
-    "    sim_i = sim_data_i.simulation.to_simulation()[0]\n",
+    "    sim_i = sim_data_i.simulation\n",
     "    sim_i.plot_eps(z=0, monitor_alpha=0.0, source_alpha=0.0, ax=ax1)\n",
     "    # ax1.set_aspect('equal')\n",
     "    \n",
@@ -40519,7 +40519,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim_final = data_history[-1].simulation.to_simulation()[0]\n",
+    "sim_final = data_history[-1].simulation\n",
     "sim_final.to_gds_file(\n",
     "    fname=\"./misc/inverse_des_wg_bend.gds\",\n",
     "    z=0,\n",


### PR DESCRIPTION
Updates a few notebooks to remove `JaxSimulation.to_simulation()` calls where safe to do so, particularly before `to_gds()` calls as this is fixed as of flexcompute/tidy3d#1660.
The changes are very conservative, I did not remove `to_simulation()` calls if the resulting simulation object is being reused for other things, such as running a simulation.