### PR TITLE
minor bug fix and update

### DIFF
--- a/MachZehnderModulator.ipynb
+++ b/MachZehnderModulator.ipynb
@@ -700,11 +700,7 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "0616fae7-dff3-4505-a901-ffde55a507ab",
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def make_y_junction(\n",
@@ -797,12 +793,12 @@
     "    \n",
     "    # adding the last point to include the straight waveguide at the output\n",
     "    x = np.append(x, x0)\n",
-    "    y = y0 + np.append(y, y[-1])\n",
+    "    y = np.append(y, y[-1])\n",
     "    \n",
     "    # add path to the cell\n",
     "    cell = gdstk.Cell(\"bends\")\n",
-    "    cell.add(gdstk.FlexPath(x + 1j * y, w1, layer=1, datatype=0))  # top waveguide bend\n",
-    "    cell.add(gdstk.FlexPath(x - 1j * y, w1, layer=1, datatype=0))  # bottom waveguide bend\n",
+    "    cell.add(gdstk.FlexPath(x + 1j * (y + y0), w1, layer=1, datatype=0))  # top waveguide bend\n",
+    "    cell.add(gdstk.FlexPath(x - 1j * (y - y0), w1, layer=1, datatype=0))  # bottom waveguide bend\n",
     "    \n",
     "    wg_bends = td.PolySlab.from_gds(\n",
     "        cell,\n",
@@ -1344,12 +1340,9 @@
    "outputs": [],
    "source": [
     "def apply_charge(electrons_data, holes_data):\n",
-    "    cs_grid = sim.discretize(box=td.Box.from_bounds(*electrons_data[0].bounds))\n",
     "    perturbed_sims = []\n",
     "    for e_data, h_data in zip(electrons_data, holes_data):\n",
-    "        e_interpolated = e_data.interp(x=0, y=cs_grid.boundaries.y, z=cs_grid.boundaries.z, fill_value=0)\n",
-    "        h_interpolated = h_data.interp(x=0, y=cs_grid.boundaries.y, z=cs_grid.boundaries.z, fill_value=0)\n",
-    "        perturbed_sims.append(sim.perturbed_mediums_copy(electron_density=e_interpolated, hole_density=h_interpolated))\n",
+    "        perturbed_sims.append(sim.perturbed_mediums_copy(electron_density=e_data, hole_density=h_data))\n",
     "    return perturbed_sims\n",
     "\n",
     "perturbed_sims = apply_charge(electrons_data, holes_data)"
@@ -4946,7 +4939,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   },
   "title": "Modeling electro-optic Mach-Zehnder modulator using Tidy3D | Flexcompute"
  },


### PR DESCRIPTION
There is a minor bug in the 'make_y_junction' function where the same offset is applied to both the top and bottom bends. The corrected code should separate the offsets for each bend:
 
```
y = y0 + np.concatenate((y / 2, -np.flipud(y / 2)))

cell.add(gdstk.FlexPath(x + 1j * y, w1, layer=1, datatype=0))  # top waveguide bend
cell.add(gdstk.FlexPath(x - 1j * y, w1, layer=1, datatype=0))  # bottom waveguide bend
```

changed to

```
y = np.concatenate((y / 2, -np.flipud(y / 2)))

cell.add(gdstk.FlexPath(x + 1j * (y + y0), w1, layer=1, datatype=0))  # top waveguide bend
cell.add(gdstk.FlexPath(x - 1j * (y - y0), w1, layer=1, datatype=0))  # bottom waveguide bend
```

Updated the 'apply_charge' function, since the Simulation.perturbed_mediums_copy method accepts now triangular grid.
New function:

```
def apply_charge(electrons_data, holes_data):
    perturbed_sims = []
    for e_data, h_data in zip(electrons_data, holes_data):
        perturbed_sims.append(sim.perturbed_mediums_copy(electron_density=e_data, hole_density=h_data))
    return perturbed_sims

perturbed_sims = apply_charge(electrons_data, holes_data)

```