### PR TITLE
corrected element mapping description

### DIFF
--- a/SMatrix.ipynb
+++ b/SMatrix.ipynb
@@ -1818,7 +1818,7 @@
     "\n",
     "\"Elements\" are defined as a tuple of output and input indices, respectively.\n",
     "\n",
-    "The element mappings are therefore defined as a tuple of `(element, element, value)` where the first `element` is set by the value of the 2nd `element` times the supplied `value`.\n",
+    "The element mappings are therefore defined as a tuple of `(element, element, value)` where the second `element` is set by the value of the 1st `element` times the supplied `value`.\n",
     "\n",
     "As an example, let's define this element mapping from the example above to enforce that the coupling between bottom left to bottom right should be equal to the coupling between top left to top right."
    ]
@@ -2907,7 +2907,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.11.8"
   },
   "title": "Scattering Matrix Computation in Tidy3D | Flexcompute",
   "widgets": {


### PR DESCRIPTION
Corrected element mapping description - the second element is equal to the first element multiplied by the factor, not the other way around