### PR TITLE
updating repo links

### DIFF
--- a/8ChannelDemultiplexer.ipynb
+++ b/8ChannelDemultiplexer.ipynb
@@ -3213,7 +3213,7 @@
    "source": [
     "Once we confirm the efficiency of the six couplers individually, we are ready to put them together to construct the entire (de)multiplexer device. This device is made by connecting the couplers via linear tapers. The linear tapers have a small angle of 1.8 degree to ensure good transmission. The overall device has a length of about 200 $\\mu m$.\n",
     "\n",
-    "The process of creating the structure is rather long and tedious. Therefore, we will skip that in this notebook and only import the constructed GDSII file. The GDSII file can be downloaded from our documentation [repo](https://github.com/flexcompute-readthedocs/tidy3d-docs/tree/readthedocs/docs/source/notebooks/misc) if needed.\n",
+    "The process of creating the structure is rather long and tedious. Therefore, we will skip that in this notebook and only import the constructed GDSII file. The GDSII file can be downloaded from our documentation [repo](https://github.com/flexcompute/tidy3d-notebooks/tree/develop/misc) if needed.\n",
     "\n",
     "There are eight input ports labeled as I1, I2, ..., I8. The top four ports are for TE0 excitation. The bottom four ports are for TM0 excitation.\n",
     "\n",

--- a/90OpticalHybrid.ipynb
+++ b/90OpticalHybrid.ipynb
@@ -148,7 +148,7 @@
    "id": "01374e67",
    "metadata": {},
    "source": [
-    "Import the MMI geometry from the stl file and define the MMI structure. All stl files used in this notebook can be downloaded from our documentation [repo](https://github.com/flexcompute-readthedocs/tidy3d-docs/tree/readthedocs/docs/source/notebooks/misc)."
+    "Import the MMI geometry from the stl file and define the MMI structure. All stl files used in this notebook can be downloaded from our documentation [repo](https://github.com/flexcompute/tidy3d-notebooks/tree/develop/misc)."
    ]
   },
   {

--- a/AdjointPlugin6GratingCoupler.ipynb
+++ b/AdjointPlugin6GratingCoupler.ipynb
@@ -590,7 +590,7 @@
    "source": [
     "### Checking For a Previous Optimization\n",
     "\n",
-    "If `history_fname` is a valid file, the results of a previous optimization are loaded, then the optimization will continue from the last iteration step. If the optimization was completed, only the final structure will be simulated. The pickle file used in this notebook can be downloaded from our documentation [repo](https://github.com/flexcompute-readthedocs/tidy3d-docs/tree/readthedocs/docs/source/notebooks/misc)."
+    "If `history_fname` is a valid file, the results of a previous optimization are loaded, then the optimization will continue from the last iteration step. If the optimization was completed, only the final structure will be simulated. The pickle file used in this notebook can be downloaded from our documentation [repo](https://github.com/flexcompute/tidy3d-notebooks/tree/develop/misc)."
    ]
   },
   {

--- a/Autograd6GratingCoupler.ipynb
+++ b/Autograd6GratingCoupler.ipynb
@@ -557,7 +557,7 @@
    "source": [
     "### Checking For a Previous Optimization\n",
     "\n",
-    "If `history_fname` is a valid file, the results of a previous optimization are loaded, then the optimization will continue from the last iteration step. If the optimization was completed, only the final structure will be simulated. The pickle file used in this notebook can be downloaded from our documentation [repo](https://github.com/flexcompute-readthedocs/tidy3d-docs/tree/readthedocs/docs/source/notebooks/misc)."
+    "If `history_fname` is a valid file, the results of a previous optimization are loaded, then the optimization will continue from the last iteration step. If the optimization was completed, only the final structure will be simulated. The pickle file used in this notebook can be downloaded from our documentation [repo](https://github.com/flexcompute/tidy3d-notebooks/tree/develop/misc)."
    ]
   },
   {

--- a/GeneticAlgorithmReflector.ipynb
+++ b/GeneticAlgorithmReflector.ipynb
@@ -156,7 +156,7 @@
    "id": "7f6e1510",
    "metadata": {},
    "source": [
-    "We will an array of length 162 to represent a design. Each element corresponds to each pixel in the design region. An element value of 1 means the pixel is silicon while an element value of 0 means the pixel is void. To facilitate the optimization, we define a helper function `create_design(pixels)` that takes the pixel array and creates the [Structures](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.Structure.html) of the simulation, inlcuding the waveguide and the design region. "
+    "We will use an array of length 162 to represent a design. Each element corresponds to each pixel in the design region. An element value of 1 means the pixel is silicon while an element value of 0 means the pixel is void. To facilitate the optimization, we define a helper function `create_design(pixels)` that takes the pixel array and creates the [Structures](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.Structure.html) of the simulation, inlcuding the waveguide and the design region. "
    ]
   },
   {

--- a/NanobeamCavity.ipynb
+++ b/NanobeamCavity.ipynb
@@ -2215,7 +2215,7 @@
   "description": "This notebook demonstrates how to run an FDTD simulation of a nanobeam cavity using Tidy3D.",
   "feature_image": "./img/NanobeamCavity_1.png",
   "features": [
-   "Resonance finer"
+   "Resonance finder"
   ],
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/Near2FarSphereRCS.ipynb
+++ b/Near2FarSphereRCS.ipynb
@@ -1332,7 +1332,7 @@
    "metadata": {},
    "source": [
     "## Plot Results\n",
-    "Now we can plot the RCS and compare it to the analytical RCS computed via the Mie series. The analytical results are stored in txt files which can be downloaded from our documentation [repo](https://github.com/flexcompute-readthedocs/tidy3d-docs/tree/readthedocs/docs/source/notebooks/misc).\n",
+    "Now we can plot the RCS and compare it to the analytical RCS computed via the Mie series. The analytical results are stored in txt files which can be downloaded from our documentation [repo](https://github.com/flexcompute/tidy3d-notebooks/tree/develop/misc).\n",
     "\n",
     "The results match very well! As expected, there are minor deviations due to the FDTD discretization.\n",
     "\n",

--- a/OptimizedL3.ipynb
+++ b/OptimizedL3.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "### Initialize geometry\n",
     "\n",
-    "To define regular photonic crystal structures, you can refer to the list of [common photonic crystal structures](https://www.flexcompute.com/tidy3d/examples/notebooks/PhotonicCrystalsComponents/). Here we will just read in hole positions and radii from file, in units of lattice constant. The file can be downloaded from our documentation [repo](https://github.com/flexcompute-readthedocs/tidy3d-docs/tree/readthedocs/docs/source/notebooks/misc).The holes are only defined in one quadrant so we have to use symmetry later on when defining the simulation. If symmetry is not applied in the simulation, we have to expand the hole list to append holes in the other quadrants. Note also that the holes correspond to a *periodic* arrangement of cavities, as for the spatial light modulator structure studied in the paper."
+    "To define regular photonic crystal structures, you can refer to the list of [common photonic crystal structures](https://www.flexcompute.com/tidy3d/examples/notebooks/PhotonicCrystalsComponents/). Here we will just read in hole positions and radii from file, in units of lattice constant. The file can be downloaded from our documentation [repo](https://github.com/flexcompute/tidy3d-notebooks/tree/develop/misc).The holes are only defined in one quadrant so we have to use symmetry later on when defining the simulation. If symmetry is not applied in the simulation, we have to expand the hole list to append holes in the other quadrants. Note also that the holes correspond to a *periodic* arrangement of cavities, as for the spatial light modulator structure studied in the paper."
    ]
   },
   {

--- a/PlasmonicYagiUdaNanoantenna.ipynb
+++ b/PlasmonicYagiUdaNanoantenna.ipynb
@@ -96,7 +96,7 @@
    "id": "7bfd9947",
    "metadata": {},
    "source": [
-    "The nanorods are made of aluminum. Before constructing the model, we first need to use the [DispersionFitter](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.plugins.dispersion.DispersionFitter.html) to fit the refractive index data of aluminum, which can be found in the [refractive index database](https://refractiveindex.info/). In particular, we use the data from [McPeak et al. 2015](https://pubs.acs.org/doi/10.1021/ph5004237). The csv file can be downloaded from our documentation [repo](https://github.com/flexcompute-readthedocs/tidy3d-docs/tree/readthedocs/docs/source/notebooks/misc). Since we are only interested in the antenna response at 570 nm, we only need to fit the refractive index in the vicinity of the operation wavelength.\n",
+    "The nanorods are made of aluminum. Before constructing the model, we first need to use the [DispersionFitter](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.plugins.dispersion.DispersionFitter.html) to fit the refractive index data of aluminum, which can be found in the [refractive index database](https://refractiveindex.info/). In particular, we use the data from [McPeak et al. 2015](https://pubs.acs.org/doi/10.1021/ph5004237). The csv file can be downloaded from our documentation [repo](https://github.com/flexcompute/tidy3d-notebooks/tree/develop/misc). Since we are only interested in the antenna response at 570 nm, we only need to fit the refractive index in the vicinity of the operation wavelength.\n",
     "\n",
     "The fitting results in a RMS error about of 0.01, which is reasonably good."
    ]

--- a/STLImport.ipynb
+++ b/STLImport.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "source": [
     "## Getting started: a simple box mesh\n",
-    "We'll start with importing an STL file representing a simple slab. We need to make sure we understand the units associated with the data in the STL file. Here, we'll assume the STL data is stored in microns. The STL files used in this tutorial can be downloaded from our documentation [repo](https://github.com/flexcompute-readthedocs/tidy3d-docs/tree/readthedocs/docs/source/notebooks/misc).\n",
+    "We'll start with importing an STL file representing a simple slab. We need to make sure we understand the units associated with the data in the STL file. Here, we'll assume the STL data is stored in microns. The STL files used in this tutorial can be downloaded from our documentation [repo](https://github.com/flexcompute/tidy3d-notebooks/tree/develop/misc).\n",
     "\n",
     "As a reference case, we'll also make a box with the same dimensions using the standard `Tidy3D` approach of making shapes: using [td.Box](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.Box.html).\n",
     "\n",


### PR DESCRIPTION
I noticed that some other notebooks have outdated repo links.

It was: https://github.com/flexcompute-readthedocs/tidy3d-docs/tree/readthedocs/docs/source/notebooks/misc
and now is: https://github.com/flexcompute/tidy3d-notebooks/tree/develop/misc

I run a simple Python code to find and replace them. I checked, and seems the files needed for the notebook are indeed in the new link.

I am not sure @tomflexcompute if I should open a PR for each file, or if it is fine to do like this.