### PR TITLE
Fixed duplicated metadata

### DIFF
--- a/AdjointPlugin0Quickstart.ipynb
+++ b/AdjointPlugin0Quickstart.ipynb
@@ -528,11 +528,14 @@
   }
  ],
  "metadata": {
+  "description": "This notebook demonstrates how to start a basic inverse design in Tidy3D FDTD using the adjoint plugin.",
+  "feature_image": "",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
+  "keywords": "inverse design, adjoint optimization, Tidy3D, FDTD",
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -544,7 +547,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.7"
-  }
+  },
+  "title": "Inverse Design Quickstart in Tidy3D Using the Adjoint Plugin | Flexcompute"
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/AdjointPlugin2GradientChecking.ipynb
+++ b/AdjointPlugin2GradientChecking.ipynb
@@ -1525,7 +1525,7 @@
   }
  ],
  "metadata": {
-  "description": "This notebook demonstrates the adjoint analysis of a multi-layer slab in Tidy3D FDTD.",
+  "description": "This notebook demonstrates the adjoint analysis of a multi-layer slab in Tidy3D FDTD using the adjoint plugin.",
   "feature_image": "",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -1543,9 +1543,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.7"
   },
-  "title": "Adjoint Analysis: Multi-layer Slab | Flexcompute",
+  "title": "Adjoint Analysis: Multi-layer Slab Using the Adjoint Plugin| Flexcompute",
   "vscode": {
    "interpreter": {
     "hash": "9e43a20ef2440406ea6cbfb61ead7c471aba2de37f508addf1f0635fad81ef64"

--- a/AdjointPlugin3InverseDesign.ipynb
+++ b/AdjointPlugin3InverseDesign.ipynb
@@ -2320,7 +2320,7 @@
   }
  ],
  "metadata": {
-  "description": "This notebook demonstrates how to perform inverse design optimization of an optical mode converter in Tidy3D FDTD.",
+  "description": "This notebook demonstrates how to perform inverse design optimization of an optical mode converter in Tidy3D FDTD using the adjoint plugin.",
   "feature_image": "./img/adjoint_3.png",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -2338,7 +2338,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.7"
   },
   "nbdime-conflicts": {
    "local_diff": [
@@ -2391,7 +2391,7 @@
     }
    ]
   },
-  "title": "Inverse Design of a Mode Converter | Flexcompute",
+  "title": "Inverse Design of a Mode Converter Using the Adjoint Plugin | Flexcompute",
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {

--- a/AdjointPlugin4MultiObjective.ipynb
+++ b/AdjointPlugin4MultiObjective.ipynb
@@ -1263,7 +1263,7 @@
   }
  ],
  "metadata": {
-  "description": "This notebook demonstrates how to perform multi-objective adjoint optimization in Tidy3D FDTD.",
+  "description": "This notebook demonstrates how to perform multi-objective adjoint optimization in Tidy3D FDTD using the adjoint plugin.",
   "feature_image": "",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -1281,9 +1281,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.7"
   },
-  "title": "Multi-objective Adjoint Optimization in Tidy3D | Flexcompute",
+  "title": "Multi-objective Adjoint Optimization in Tidy3D Using the Adjoint Plugin| Flexcompute",
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {

--- a/AdjointPlugin5BoundaryGradients.ipynb
+++ b/AdjointPlugin5BoundaryGradients.ipynb
@@ -2875,7 +2875,7 @@
   }
  ],
  "metadata": {
-  "description": "This notebook demonstrates how to perform inverse design optimization of a waveguide taper using boundary gradients in Tidy3D FDTD.",
+  "description": "This notebook demonstrates how to perform inverse design optimization of a waveguide taper using boundary gradients in Tidy3D FDTD using the adjoint plugin.",
   "feature_image": "./img/adjoint_5.png",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -2893,9 +2893,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.7"
   },
-  "title": "Inverse Design of a Waveguide Taper in Tidy3D | Flexcompute",
+  "title": "Inverse Design of a Waveguide Taper in Tidy3D Using the Adjoint Plugin | Flexcompute",
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {

--- a/AdjointPlugin6GratingCoupler.ipynb
+++ b/AdjointPlugin6GratingCoupler.ipynb
@@ -1176,7 +1176,7 @@
   }
  ],
  "metadata": {
-  "description": "This notebook demonstrates the inverse design of a compact 3D grating coupler with permittivity binarization and minimum feature size control.",
+  "description": "This notebook demonstrates the inverse design of a compact 3D grating coupler with permittivity binarization and minimum feature size control using the adjoint plugin.",
   "feature_image": "./img/adjoint_6.png",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -1194,7 +1194,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.7"
   },
   "nbdime-conflicts": {
    "local_diff": [
@@ -1258,7 +1258,7 @@
     }
    ]
   },
-  "title": "Inverse Design of a Grating Coupler in Tidy3D | Flexcompute",
+  "title": "Inverse Design of a Grating Coupler in Tidy3D Using the Adjoint Plugin | Flexcompute",
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {

--- a/AdjointPlugin7Metalens.ipynb
+++ b/AdjointPlugin7Metalens.ipynb
@@ -1637,7 +1637,7 @@
     }
    ]
   },
-  "title": "Adjoint Optimization of a Metalens in Tidy3D | Flexcompute",
+  "title": "Adjoint Optimization of a Metalens in Tidy3D Using the Adjoint Plugin| Flexcompute",
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {

--- a/AdjointPlugin8WaveguideBend.ipynb
+++ b/AdjointPlugin8WaveguideBend.ipynb
@@ -40548,9 +40548,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.7"
   },
-  "title": "Adjoint Optimization of a Waveguide Bend in Tidy3D | Flexcompute"
+  "title": "Adjoint Optimization of a Waveguide Bend in Tidy3D Using the Adjoint Plugin| Flexcompute"
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/Autograd0Quickstart.ipynb
+++ b/Autograd0Quickstart.ipynb
@@ -531,11 +531,14 @@
   }
  ],
  "metadata": {
+  "description": "This notebook demonstrates how to start a basic inverse design in Tidy3D FDTD.",
+  "feature_image": "",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
+  "keywords": "inverse design, adjoint optimization, Tidy3D, FDTD",
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -546,8 +549,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
-  }
+   "version": "3.11.7"
+  },
+  "title": "Inverse Design Quickstart in Tidy3D | Flexcompute"
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/Autograd1Intro.ipynb
+++ b/Autograd1Intro.ipynb
@@ -1785,14 +1785,14 @@
   }
  ],
  "metadata": {
-  "description": "This notebook introduces the basics of Jax, automatic differentiation, and the adjoint plugin in Tidy3D FDTD.",
+  "description": "This notebook introduces the basics of automatic differentiation and the adjoint optimization in Tidy3D FDTD.",
   "feature_image": "",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
-  "keywords": "adjoint optimization, Jax, automatic differentiation, Tidy3D, FDTD",
+  "keywords": "adjoint optimization, autograd, automatic differentiation, Tidy3D, FDTD",
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1803,9 +1803,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.7"
   },
-  "title": "FDTD Adjoint Optimization Basics | Flexcompute",
+  "title": "FDTD Adjoint Optimization Basics using Autograd | Flexcompute",
   "vscode": {
    "interpreter": {
     "hash": "9e43a20ef2440406ea6cbfb61ead7c471aba2de37f508addf1f0635fad81ef64"

--- a/Autograd3InverseDesign.ipynb
+++ b/Autograd3InverseDesign.ipynb
@@ -2146,7 +2146,7 @@
   "feature_image": "./img/adjoint_3.png",
   "features": [
    "Adjoint inverse design",
-   "2D Simulation"
+   "2D simulation"
   ],
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/Autograd7Metalens.ipynb
+++ b/Autograd7Metalens.ipynb
@@ -1229,7 +1229,7 @@
   "applications": [
    "Metamaterials, gratings, and other periodic structures"
   ],
-  "description": "This notebook demonstrates the adjoint optimization of a metalens in Tidy3D using the adjoint plugin.",
+  "description": "This notebook demonstrates the adjoint optimization of a metalens in Tidy3D using autograd.",
   "feature_image": "./img/adjoint_7.png",
   "features": [
    "Adjoint inverse design"

--- a/Autograd8WaveguideBend.ipynb
+++ b/Autograd8WaveguideBend.ipynb
@@ -1628,7 +1628,7 @@
   "applications": [
    "Passive photonic integrated circuit components"
   ],
-  "description": "This notebook demonstrates the adjoint optimization of a waveguide bend in Tidy3D using the adjoint plugin.",
+  "description": "This notebook demonstrates the adjoint optimization of a waveguide bend in Tidy3D using autograd.",
   "feature_image": "./img/adjoint_8.png",
   "features": [
    "Adjoint inverse design"

--- a/GeometryTransformations.ipynb
+++ b/GeometryTransformations.ipynb
@@ -5,7 +5,7 @@
    "id": "9c111917-c842-4ba3-9220-793cf43a5dd7",
    "metadata": {},
    "source": [
-    "# Geometry Transformations\n",
+    "# Geometry transformations\n",
     "\n",
     "Tidy3D has a rich set of classes and functions for the creation complex geometries. The set of primitive solids supported is:\n",
     "\n",
@@ -697,7 +697,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   },
   "title": "Apply Geometry Transformations in Tidy3D | Flexcompute"
  },


### PR DESCRIPTION
The metadata in the adjoint plugin notebooks is duplicated with the autograd notebooks. MC found this an issue for website SEO. This PR removes the duplications.