### PR TITLE
:wrench: Verified correct bullet point structure

### DIFF
--- a/CharacteristicImpedanceCalculator.ipynb
+++ b/CharacteristicImpedanceCalculator.ipynb
@@ -11,10 +11,14 @@
     "The microstrip, a type of transmission line with a conductor strip separated from a ground plane by a dielectric layer, will serve as our example for the study. We will demonstrate how to use the post processing tools available in the `microwave` plugin to determine the voltage and current distribution along the microstrip both in the time and frequency domains.\n",
     "\n",
     "The notebook is structured as follows:\n",
-    "- Set up structures and simulation parameters for a microstrip transmission line.\n",
-    "- Computation of the voltage and current using path integrals.\n",
-    "- Calculation of the characteristic impedance.\n",
-    "- Final simulation of a microstrip terminated by a matched load.\n",
+    "\n",
+    "1. Set up structures and simulation parameters for a microstrip transmission line.\n",
+    "\n",
+    "2. Computation of the voltage and current using path integrals.\n",
+    "\n",
+    "3. Calculation of the characteristic impedance.\n",
+    "\n",
+    "4. Final simulation of a microstrip terminated by a matched load.\n",
     "\n",
     "By the end of this notebook, you will have a clear understanding of how to use Tidy3D for simulating and analyzing the characteristic impedance of transmission lines, as well as many of the building blocks used within microwave simulations."
    ]
@@ -1520,7 +1524,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.10.14"
   },
   "title": "Computing the characteristic impedance of transmission lines using Tidy3D"
  },


### PR DESCRIPTION
Turns out we have to add spaces between the bullet points like [Primer.ipynb](https://docs.flexcompute.com/projects/tidy3d/en/latest/notebooks/Primer.html). I've tried grepping but hard to match so can catch them as it comes up in the docs.