### PR TITLE
Updated TPA notebook header to h1 level

### DIFF
--- a/SiWaveguideTPA.ipynb
+++ b/SiWaveguideTPA.ipynb
@@ -5,7 +5,7 @@
    "id": "77a6ec47-b8ac-42ea-92c4-cd07f09991b2",
    "metadata": {},
    "source": [
-    "## Two-photon absorption (TPA) and free-carrier absorption (FCA) in a Si waveguide\n",
+    "# Two-photon absorption (TPA) and free-carrier absorption (FCA) in a Si waveguide\n",
     "\n",
     "In this notebook, we will reproduce part of the experimental results in `Rong, H., Liu, A., Jones, R. et al. An all-silicon Raman laser. Nature 433, 292–294 (2005)` [DOI: 10.1038/nature03273](https://doi.org/10.1038/nature03273). Specifically, the authors provided experimental results for the input-output power relationship for a 4.8cm long rib waveguide, with the output power following a non-linear dependence on the input power due to two-photon absorption (TPA) and free-carrier absorption (FCA) effects. All of the physical parameters are provided in the paper which makes for a great benchmark to reproduce with the first-principle TPA and FCA support in the Tidy3D solver.\n",
     "\n",


### PR DESCRIPTION
This PR fixes the TPA notebook title, which needs to be a h1 header to be rendered correctly on the docs and learning center.