### PR TITLE
run notebook checks on pre branches

### DIFF
--- a/.github/workflows/lint-notebooks.yml
+++ b/.github/workflows/lint-notebooks.yml
@@ -2,9 +2,13 @@ name: "notebook checks"
 
 on:
   push:
-    branches: [ develop ]
+    branches:
+      - develop
+      - "pre/**"
   pull_request:
-    branches: [ develop ]
+    branches:
+      - develop
+      - "pre/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Run the notebook-check workflow for `pre/...` branches in addition to `develop`.

## Root Cause

`.github/workflows/lint-notebooks.yml` only triggered on `develop` for both `push` and `pull_request`, so PRs targeting `pre/...` branches skipped the notebook checks entirely.

## Changes

- add `pre/**` to the `push` branch filter
- add `pre/**` to the `pull_request` branch filter

## Validation

- `actionlint .github/workflows/lint-notebooks.yml`

## Impact

PRs and pushes on `pre/...` branches now run the same notebook checks as `develop`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change with no application or security logic; slightly broader workflow execution on pre branches.
> 
> **Overview**
> Extends the **notebook checks** workflow so it runs on `pre/**` branches the same way it already runs on `develop`.
> 
> For both `push` and `pull_request`, the branch filters are expanded from a single `develop` entry to a list that includes `develop` and `"pre/**"`. Pushes and PRs targeting pre-release branches will now get ruff, metadata validation, misc reference checks, and related notebook gates instead of skipping the workflow entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c1e6fce0c5e2cd9c99d1cb536c6e5f9cbaced88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->