### PR TITLE
Clean up notebook misc import mapping

### DIFF
--- a/misc/check_misc_references.py
+++ b/misc/check_misc_references.py
@@ -17,6 +17,9 @@ from pathlib import Path
 
 # Methods that write files to misc directory (these references should be ignored)
 WRITE_METHODS = [
+    "save",
+    "savetxt",
+    "to_stl",
     "write_gds",
     "to_gds_file",
     "to_file",
@@ -25,12 +28,18 @@ WRITE_METHODS = [
 # Variable name patterns that indicate output/write file paths
 # These are checked as substrings in variable names before "="
 WRITE_VAR_PATTERNS = [
+    "gc_file",
     "history_fname",
     "history_file_path",
+    "npy_export_path",
+    "restart_fname",
+    "stl_export_path",
 ]
 
 # File name whitelist - these are output files that should be ignored
 WRITE_FILE_WHITELIST = [
+    "fiber_lens.stl",
+    "fiber_lens_params.npy",
     "my_medium.json",
     "inv_des_diamond_light_extractor.gds",
 ]

--- a/misc/import_file_mapping.json
+++ b/misc/import_file_mapping.json
@@ -6,34 +6,8 @@
         "mmi_stl.stl",
         "optical_hybrid_stl.stl"
     ],
-    "Autograd10YBranchLevelSet.ipynb": [
-        "y_branch_fab.pkl",
-        "inv_des_ybranch.gds"
-    ],
-    "Autograd12LightExtractor.ipynb": [
-        "qe_light_coupler.pkl",
-        "inv_des_light_extractor.gds"
-    ],
     "Autograd13Metasurface.ipynb": [
         "logo.png"
-    ],
-    "Autograd28FiberLens.ipynb": [
-        "fiber_lens.stl",
-        "fiber_lens_params.npy"
-    ],
-    "Autograd3InverseDesign.ipynb": [
-        "inv_des_mode_conv.gds"
-    ],
-    "Autograd6GratingCoupler.ipynb": [
-        "invdes_gc.json",
-        "inverse_designed_gc.gds",
-        "grating_coupler_history_autograd.pkl"
-    ],
-    "Autograd8WaveguideBend.ipynb": [
-        "inverse_des_wg_bend.gds"
-    ],
-    "Autograd9WDM.ipynb": [
-        "inv_des_wdm.gds"
     ],
     "CMOSRGBSensor.ipynb": [
         "green_eps.csv",
@@ -46,14 +20,8 @@
     "Fitting.ipynb": [
         "nk_data.csv"
     ],
-    "FocusedApodGC.ipynb": [
-        "Focusing_GC.gds"
-    ],
     "FreeFormCoupler.ipynb": [
         "chip_to_chip_coupler.stl"
-    ],
-    "GDSExport.ipynb": [
-        "dc_export_gds.gds"
     ],
     "GDSImport.ipynb": [
         "coupler.gds"
@@ -100,10 +68,6 @@
     "RadiativeCoolingGlass.ipynb": [
         "mat_SiO2.csv",
         "mat_Al2O3.csv"
-    ],
-    "RFAutograd1RectangularPatchAntenna.ipynb": [
-        "rf_autograd_1_patch_antenna_optimization.npy",
-        "rf_autograd_1_patch_opt_state.pkl"
     ],
     "STLImport.ipynb": [
         "box.stl",


### PR DESCRIPTION
## Summary

- remove generated exports, optional checkpoints, and stale missing files from `misc/import_file_mapping.json`
- keep the mapping limited to bundled input resources used by notebooks
- extend `check_misc_references.py` write-path heuristics so generated files are not re-added or reported as missing imports

## Why

The import file mapping is consumed by downstream notebook download packaging. Several entries pointed at files that are either generated by notebooks or absent from `misc/`, so strict packaging treated them as missing bundled inputs.

## Validation

- `python3 -m json.tool misc/import_file_mapping.json >/dev/null`
- `python3 -m py_compile misc/check_misc_references.py`
- `python3 misc/check_misc_references.py`
- audited remaining mappings: 42 mapped files, 0 missing mapped resources

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only misc packaging metadata and a local reference checker; no application runtime or security-sensitive logic.
> 
> **Overview**
> **Trims `misc/import_file_mapping.json`** so it only lists bundled notebook *inputs* (e.g. GDS/STL/CSV under `misc/`). Removed mappings for Autograd inverse-design notebooks, GDS export, RF autograd, and similar cases where listed files are notebook-generated or were not present in `misc/`, which had caused strict download packaging to treat them as missing bundled assets.
> 
> **Extends `misc/check_misc_references.py` write-path detection** with additional export methods (`save`, `savetxt`, `to_stl`), output variable name patterns (`gc_file`, `npy_export_path`, `restart_fname`, `stl_export_path`), and whitelisted generated filenames (`fiber_lens.stl`, `fiber_lens_params.npy`) so references in write contexts are ignored and not pushed back into the mapping via `--fix`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f53436811559536f40c32cc39de930c2f2953ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->