### PR TITLE
fix(notebooks): Fix notebook metadata

### DIFF
--- a/Autograd27Smatrix.ipynb
+++ b/Autograd27Smatrix.ipynb
@@ -2098,7 +2098,7 @@
   "applications": [
    "Passive photonic integrated circuit components"
   ],
-  "description": "This notebook demonstrates the adjoint optimization of a wavelength division multiplexer using autograd.",
+  "description": "This notebook demonstrates inverse design of a compact waveguide crossing using S-matrix optimization in Tidy3D.",
   "feature_image": "./img/adjoint_27.png",
   "features": [
    "Adjoint inverse design",
@@ -2109,7 +2109,7 @@
    "language": "python",
    "name": "tidy3d-autograd-upload-fix"
   },
-  "keywords": "inverse design, WDM, design optimization, adjoint, Tidy3D, FDTD",
+  "keywords": "inverse design, waveguide crossing, S-matrix, design optimization, adjoint, Tidy3D, FDTD",
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -2122,7 +2122,7 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.20"
   },
-  "title": "Adjoint Optimization of a WDM in Tidy3D | Flexcompute"
+  "title": "Inverse Design of a Waveguide Crossing Using S-Matrix Optimization in Tidy3D | Flexcompute"
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/DirectionalCoupler.ipynb
+++ b/DirectionalCoupler.ipynb
@@ -943,7 +943,7 @@
   "applications": [
    "Passive photonic integrated circuit components"
   ],
-  "description": "This notebook demonstrates how to import geometries from a gds file to Tidy3D for FDTD simulations.",
+  "description": "This notebook demonstrates how to model a directional coupler in Tidy3D FDTD.",
   "feature_image": "./img/DirectionalCoupler.png",
   "features": [
    "Parameter sweep"
@@ -953,7 +953,7 @@
    "language": "python",
    "name": "python3"
   },
-  "keywords": "gds, import, Tidy3D, FDTD",
+  "keywords": "directional coupler, integrated photonics, power splitter, parameter sweep, Tidy3D, FDTD",
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -966,7 +966,7 @@
    "pygments_lexer": "ipython3",
    "version": "3.11.7"
   },
-  "title": "GDS File Import in Tidy3D | Flexcompute"
+  "title": "Directional Coupler in Tidy3D | Flexcompute"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/MetasurfaceBIC.ipynb
+++ b/MetasurfaceBIC.ipynb
@@ -869,7 +869,7 @@
   "applications": [
    "Metamaterials, gratings, and other periodic structures"
   ],
-  "description": "This notebook presents a simulation of the blocking properties of a metal oxide-based sunscreen using Tidy3D.",
+  "description": "This notebook demonstrates quasi-bound states in the continuum in symmetry-breaking dielectric metasurfaces using Tidy3D.",
   "feature_image": "./img/metasurface_qbic.png",
   "features": [
    "Parameter sweep",

--- a/TopoQuantumPhC.ipynb
+++ b/TopoQuantumPhC.ipynb
@@ -696,7 +696,7 @@
    "language": "python",
    "name": "python3"
   },
-  "keywords": "two photon absorption, TPA, FCA, free carrier absorption, silicon, photonics, waveguide, Tidy3D, FDTD",
+  "keywords": "topological photonic crystal, edge states, chiral edge states, quantum emitters, photonic crystal, Tidy3D, FDTD",
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",


### PR DESCRIPTION
## Summary

Fix only stale source publication metadata on `pre/2.12` before the compute Quarto migration consumes it.

- correct copied GDS import metadata on `DirectionalCoupler`; the notebook is a directional coupler tutorial, not a GDS import tutorial
- correct copied WDM metadata on `Autograd27Smatrix`; the notebook is a waveguide crossing S-matrix optimization tutorial, not a WDM tutorial
- correct the sunscreen description on `MetasurfaceBIC`; the notebook is about qBIC dielectric metasurfaces
- correct `TopoQuantumPhC` keywords; the notebook is about topological photonic crystal edge states and quantum emitters, while the old keywords were for TPA/FCA/free-carrier absorption
- intentionally leave notebook `kernelspec`, thumbnails, `ParameterScanWebRun`, and `ModeSimulation` untouched; the migration/publication path should ignore kernelspec metadata

## Validation

- parsed every `*.ipynb` as JSON
- compared changed notebooks against `origin/pre/2.12` and verified `cells` arrays are unchanged, so no source cells or outputs changed
- checked the diff has no changed `kernelspec`, `display_name`, kernel `name`, thumbnail metadata, `ParameterScanWebRun`, or `ModeSimulation` lines
- ran `git diff --check origin/pre/2.12 --`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only metadata edits with no simulation code, kernelspec, or cell changes.
> 
> **Overview**
> Updates **publication metadata only** in four Tidy3D example notebooks so titles, descriptions, and keywords match the actual tutorials before a Quarto migration reads them. No notebook cells or outputs change.
> 
> **`DirectionalCoupler.ipynb`** — Replaces incorrect GDS-import copy with directional coupler / parameter-sweep metadata. **`Autograd27Smatrix.ipynb`** — Replaces WDM wording with waveguide crossing S-matrix inverse design. **`MetasurfaceBIC.ipynb`** — Replaces sunscreen description with qBIC dielectric metasurface content. **`TopoQuantumPhC.ipynb`** — Replaces TPA/FCA keyword set with topological photonic crystal / edge-state terms.
> 
> Kernelspecs, thumbnails, and other migration-ignored fields are left unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1342483376e79097b3e9b6fefe59eed4b11386c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->