### PR TITLE
add anisotropic eme to ignore list

### DIFF
--- a/checks/notebook_check_ignores.json
+++ b/checks/notebook_check_ignores.json
@@ -51,6 +51,7 @@
     "SWGBroadbandPolarizer.ipynb",
     "SelfIntersectingPolyslab.ipynb",
     "ThermoOpticDopedModulator.ipynb",
-    "WebAPI.ipynb"
+    "WebAPI.ipynb",
+    "AnisotropicBendsEME.ipynb"
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only change to notebook check allowlists with no runtime or security impact.
> 
> **Overview**
> Adds **`AnisotropicBendsEME.ipynb`** to the `private_path_ignored_notebooks` list in `checks/notebook_check_ignores.json`, so notebook CI no longer enforces private-path rules on that example.
> 
> Also fixes JSON formatting by adding a trailing comma after **`WebAPI.ipynb`** now that it is no longer the last entry in the array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdfbbdc07732111be1ce02239a4c389d0f0f76c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->